### PR TITLE
fixed metadata popup

### DIFF
--- a/source/stylesheets/lib/theme.sass
+++ b/source/stylesheets/lib/theme.sass
@@ -719,3 +719,36 @@ section#content .external
 #search-form .btn
   padding: 0.35ex
   border-radius: 1px
+
+// Style frontmatter metadata a bit better
+
+.frontmatter-metadata
+  background: #fed
+  border: 1px solid #eee
+  border-radius: 3px
+  max-width: 33%
+  margin-left: 1rem
+  opacity: 0
+  position: absolute
+  right: 0
+  top: 0
+  transition: 500ms all
+  z-index: -1
+
+  float: right
+
+  table
+    opacity: 0.75
+    width: auto
+    margin: 1ex 1ex 0.75ex
+
+    th, td
+      font-size: 88%
+
+.alert:hover .frontmatter-metadata
+  opacity: 1
+  z-index: 10
+
+.front-page
+  .frontmatter-metadata
+    display: none


### PR DESCRIPTION
Added CSS that's similar to the oVirt middleman conversion WIP, where the metadata is hidden until the right side of the debugbar is hovered over.