### PR TITLE
use the site.yml specified domain (not harcoded to ovirt.org)

### DIFF
--- a/source/site/redirects.html.haml
+++ b/source/site/redirects.html.haml
@@ -75,8 +75,8 @@ index: false
       - $processed.each do |item|
         %tr
           %td
-            %a{href: "http://ovirt.org/#{item[:orig]}", target: "_blank"}
-              %span.fa-external-link{title: "view the link on oVirt.org", target: "_blank"}
+            %a{href: "http://#{data.site.domain}/#{item[:orig]}", target: "_blank"}
+              %span.fa-external-link{title: "view the link on #{data.site.domain}", target: "_blank"}
 
           %td
             %a{href: item[:mw_path], title: "local link — should be remapped to new path via Apache .htaccess rules", target: "_blank"}


### PR DESCRIPTION
I accidentally left this hardcoded from when I originally wrote it for oVirt.org. It now should work for whatever is specified in `data/site.yml` — which, in our case, is [rdoproject.org](http://rdoproject.org/).