### PR TITLE
added warnings for all tables converted from the wiki

### DIFF
--- a/source/hardware/home-lab.html.md
+++ b/source/hardware/home-lab.html.md
@@ -6,6 +6,7 @@ wiki_category: Hardware
 wiki_title: Home lab
 wiki_revision_count: 12
 wiki_last_updated: 2015-03-09
+wiki_warnings: table
 ---
 
 # Home lab

--- a/source/howto/test.html.md
+++ b/source/howto/test.html.md
@@ -5,6 +5,7 @@ authors: eglynn
 wiki_title: HowToTest
 wiki_revision_count: 3
 wiki_last_updated: 2013-10-23
+wiki_warnings: table
 ---
 
 {:.no_toc}

--- a/source/uncategorized/bugzilla-ownership.html.md
+++ b/source/uncategorized/bugzilla-ownership.html.md
@@ -4,6 +4,7 @@ authors: gfidente, mburns, pixelbeat, sdake, tosky
 wiki_title: Bugzilla ownership
 wiki_revision_count: 12
 wiki_last_updated: 2014-08-07
+wiki_warnings: table
 ---
 
 # Bugzilla ownership

--- a/source/uncategorized/rdo-test-day-juno-milestone-3-test-cases.html.md
+++ b/source/uncategorized/rdo-test-day-juno-milestone-3-test-cases.html.md
@@ -7,6 +7,7 @@ authors: ajeain, arifali, avladu, cmyster, coolsvap, dron, gszasz, iovadia, kash
 wiki_title: RDO test day Juno milestone 3 test cases
 wiki_revision_count: 101
 wiki_last_updated: 2014-10-14
+wiki_warnings: table
 ---
 
 # RDO test day Juno milestone 3 test cases

--- a/source/uncategorized/rdo-test-day-kilo-rc-milestone-test-cases.html.md
+++ b/source/uncategorized/rdo-test-day-kilo-rc-milestone-test-cases.html.md
@@ -6,6 +6,7 @@ authors: ajeain, apevec, berendt, bkopilov, dbaxps, ekuris, eyepv6, iovadia, itz
 wiki_title: RDO test day Kilo RC milestone test cases
 wiki_revision_count: 67
 wiki_last_updated: 2015-05-12
+wiki_warnings: table
 ---
 
 # RDO test day Kilo RC milestone test cases

--- a/source/uncategorized/release-cadence.html.md
+++ b/source/uncategorized/release-cadence.html.md
@@ -4,6 +4,7 @@ authors: apevec, kashyap, larsks
 wiki_title: Release-Cadence
 wiki_revision_count: 6
 wiki_last_updated: 2015-03-18
+wiki_warnings: table
 ---
 
 # Release-Cadence

--- a/source/uncategorized/testedsetups-2014-01.html.md
+++ b/source/uncategorized/testedsetups-2014-01.html.md
@@ -7,6 +7,7 @@ authors: amuller, bcrochet, cgirda, dron, edu, flaper87, gfidente, ihrachys, jar
 wiki_title: TestedSetups 2014 01
 wiki_revision_count: 132
 wiki_last_updated: 2014-02-21
+wiki_warnings: table
 ---
 
 # TestedSetups 2014 01

--- a/source/uncategorized/testedsetups-2014-02.html.md
+++ b/source/uncategorized/testedsetups-2014-02.html.md
@@ -5,6 +5,7 @@ authors: gfidente, mpavlase, oblaut, ohochman, panda, rbowen, rlandy, verdurin, 
 wiki_title: TestedSetups 2014 02
 wiki_revision_count: 33
 wiki_last_updated: 2014-02-06
+wiki_warnings: table
 ---
 
 # TestedSetups 2014 02

--- a/source/uncategorized/testedsetups.html.md
+++ b/source/uncategorized/testedsetups.html.md
@@ -6,6 +6,7 @@ authors: acalinciuc, derekh, dron, gdubreui, jayg, jdennis, jlibosva, jruzicka, 
 wiki_title: TestedSetups
 wiki_revision_count: 134
 wiki_last_updated: 2014-01-06
+wiki_warnings: table
 ---
 
 # Tested Setups


### PR DESCRIPTION
MediaWiki supports more table markup than Kramdown (the extended Markdown we use) does.

As a result, all of these pages need to be manually reviewed, and some need to be changed. Please see issue #18 for more details.