### PR TITLE
Add link to Delorean repo in f22

### DIFF
--- a/source/testday/rdo-test-day-liberty-01.html.md
+++ b/source/testday/rdo-test-day-liberty-01.html.md
@@ -33,10 +33,12 @@ You'll want a fresh install with latest updates installed.
     sudo wget http://trunk.rdoproject.org/centos7-liberty/delorean-deps.repo
     sudo wget http://trunk.rdoproject.org/centos7-liberty/current-passed-ci/delorean.repo
     # for Fedora 22
+    sudo wget http://trunk.rdoproject.org/f22/current/delorean.repo
     sudo wget http://trunk.rdoproject.org/f22/delorean-deps.repo
 
 * Check for any [workarounds](/testday/workarounds-liberty-01) required for your platform before the main installation
 * For Packstack based deployment start at step 2 of the [packstack Quickstart](http://openstack.redhat.com/Quickstart#Step_2:_Install_Packstack_Installer)
+* **Note**: Please be aware that the Fedora 22 packages have not gone through CI
 
 ### Test cases and results
 


### PR DESCRIPTION
Previously, only the delorean-deps.repo file was included, so we
ended up using Kilo packages. Also, add warning that f22 packages
haven't passed CI.