### PR TITLE
Update Trystack doc. #128

### DIFF
--- a/source/documentation/using-rdo-on-trystack.html.md
+++ b/source/documentation/using-rdo-on-trystack.html.md
@@ -10,7 +10,11 @@ wiki_last_updated: 2013-06-05
 
 # Using RDO on TryStack
 
-If you want to get familiar with the OpenStack dashboard interface, and experiment with the creation of instances and shared volumes, [TryStack](http://trystack.org) could be for you. If you connect to "OpenStack Grizzly on x86/RHEL", you will be connecting to a public sandboxed instance of RDO, on hardware which has been contributed by Red Hat, and installed and maintained by [ Dan Radez](People#radez), a member of Red Hat's OpenStack team.
+If you want to get familiar with the OpenStack dashboard interface, 
+and experiment with the creation of instances and shared volumes, 
+[TryStack](http://trystack.org) could be for you. 
+If you connect to "OpenStack RDO Kilo on x86/RHEL", 
+you will be connecting to a public sandboxed instance of RDO.
 
 # Signing up
 

--- a/source/install/index.html.md
+++ b/source/install/index.html.md
@@ -32,7 +32,7 @@ install directory**
 *   [Getting started with Ceilometer](CeilometerQuickStart)
 *   [Launching your first VM ](Running an instance)
 *   [Image Resources](Image resources)
-*   [Deploy Heat and launch your first Application (RDO Grizzly)](Deploy Heat and launch your first Application)
+*   [Deploy Heat and launch your first Application (RDO Grizzly)](Deploy Heat and launch your first Application) 
 *   [Deploy Heat and launch your first Application (RDO Havana)](DeployHeatOnHavana)
 *   [Repository information ](Repositories)
 *   [Adding a compute node](Adding a compute node)


### PR DESCRIPTION
Removes reference to Grizzly, as Trystack is now running Kilo. Remember to update to Liberty when Trystack updates.