### PR TITLE
RHOSP as abbreviation for RHEL OSP looks strange

### DIFF
--- a/source/community/repositories.html.md
+++ b/source/community/repositories.html.md
@@ -49,7 +49,7 @@ The packages used from rhel-z channel are:
 
 *   rubygems
 
-### RHOSP
+### RHEL-OSP
 
 The separate [Red Hat Enterprise Linux OpenStack Platform](http://redhat.com/openstack) product does **not** require the Optional channel or EPEL enabled.
 


### PR DESCRIPTION
I thought, it's abbreviated as RHEL OSP