### PR TITLE
navigation reworked to have fewer items

### DIFF
--- a/data/navigation.yml
+++ b/data/navigation.yml
@@ -1,7 +1,6 @@
 - Home: '/'
-- Quick Start: /install/quickstart
-- Docs: /documentation/
-- Events: /events/
 - Blog: /blog/
-- Get Involved: /community/
+- Events: /events/
+- Community: /community/
+- Docs: /documentation/
 - Search: /search/


### PR DESCRIPTION
1. quickstart is included right under the nav on the front page and
   should be highlighted under docs too (not in this patch)
2. 'get involved' was inconsistent & verbose; changed to 'community'
3. navigation items were shuffled in order of dynamic to utility