### PR TITLE
URL (and MediaWiki titles) as search keywords

### DIFF
--- a/source/search-results.json.haml
+++ b/source/search-results.json.haml
@@ -66,7 +66,8 @@ index: false
                "whether", "which", "while", "whither", "who", "whoever",
                "whole", "whom", "whose", "why", "will", "with",
                "within", "without", "would", "yet", "you", "your",
-               "yours", "yourself", "yourselves", "the"]
+               "yours", "yourself", "yourselves", "the",
+               ".", "-", ":", "/", "\\"]
 
   # Cache results in a global session variable (restart session for updates)
   unless defined?($searchdata)

--- a/source/search-results.json.haml
+++ b/source/search-results.json.haml
@@ -128,6 +128,10 @@ index: false
 
       titlewords = page_title.downcase.split(wordsplit).map(&:strip)
 
+      # Make URL fragments from simpliy splitting dirs
+      # ...and also simpler keywords by splitting at other ASCII chars
+      url_frags = page.url.split('/') + page.url.tr('_/-:', ' ').split(' ')
+
       nickname = page.data.author
       author = []
 
@@ -139,7 +143,7 @@ index: false
       text = page_content.downcase.split(wordsplit) + titlewords
 
       text = text.map(&:strip).sort.uniq
-        .reject {|w| w.match /[=]/} - stopwords + author
+        .reject {|w| w.match /[=]/} + url_frags - stopwords + author
 
       # Add CJK words to the word list
       text += page_content.scan(/\p{Han}/).uniq

--- a/source/search-results.json.haml
+++ b/source/search-results.json.haml
@@ -132,6 +132,23 @@ index: false
       # ...and also simpler keywords by splitting at other ASCII chars
       url_frags = page.url.split('/') + page.url.tr('_/-:', ' ').split(' ')
 
+      # MediaWiki name/URL titles
+      # (empty if wiki_title doesn't exist — only used for MW conversions)
+      mw_frags = if page.data['wiki_title']
+                   puts page.data['wiki_title']
+                     .downcase
+                     .tr('_/-:', ' ')
+                     .squeeze(' ')
+                     .split(' ').to_yaml
+                   page.data['wiki_title']
+                     .downcase
+                     .tr('_/-:', ' ')
+                     .squeeze(' ')
+                     .split(' ')
+                 else
+                   []
+                 end
+
       nickname = page.data.author
       author = []
 
@@ -143,7 +160,7 @@ index: false
       text = page_content.downcase.split(wordsplit) + titlewords
 
       text = text.map(&:strip).sort.uniq
-        .reject {|w| w.match /[=]/} + url_frags - stopwords + author
+        .reject {|w| w.match /[=]/} + url_frags + mw_frags - stopwords + author
 
       # Add CJK words to the word list
       text += page_content.scan(/\p{Han}/).uniq

--- a/source/search-results.json.haml
+++ b/source/search-results.json.haml
@@ -135,11 +135,6 @@ index: false
       # MediaWiki name/URL titles
       # (empty if wiki_title doesn't exist — only used for MW conversions)
       mw_frags = if page.data['wiki_title']
-                   puts page.data['wiki_title']
-                     .downcase
-                     .tr('_/-:', ' ')
-                     .squeeze(' ')
-                     .split(' ').to_yaml
                    page.data['wiki_title']
                      .downcase
                      .tr('_/-:', ' ')


### PR DESCRIPTION
Adds URL fragments and MediaWiki-based titles to search index. This improves searching, as URLs will now match... which means 404-based searches will now be even better too.

(Ported from: https://github.com/oVirt/ovirt-site/pull/41)