### PR TITLE
Display the 'edit on github' ribbon everywhere except the events page.

### DIFF
--- a/source/layouts/_header.haml
+++ b/source/layouts/_header.haml
@@ -19,8 +19,10 @@
 
 %header#branding.masthead.hidden-print(role="banner")
 
-  %a{:href => github_url }
-    %img{:alt => "Edit on GitHub", "data-canonical-src" => "/images/edit.png", :src => "/images/edit.png", :style => "position: absolute; top: 0; right: 0; border: 0;"}
+  - if source_file.match /events/
+  - else
+    %a{:href => github_url }
+      %img{:alt => "Edit on GitHub", "data-canonical-src" => "/images/edit.png", :src => "/images/edit.png", :style => "position: absolute; top: 0; right: 0; border: 0;"}
 
   %section.hgroup
     %h1


### PR DESCRIPTION
We don't want the 'edit on github' ribbon on the events page, because that's not how you edit events.