### PR TITLE
Show the 'edit on github' ribbon on events sub pages, just not on the…

### DIFF
--- a/source/layouts/_header.haml
+++ b/source/layouts/_header.haml
@@ -19,7 +19,7 @@
 
 %header#branding.masthead.hidden-print(role="banner")
 
-  - if source_file.match /events/
+  - if source_file.match /events\/index/
   - else
     %a{:href => github_url }
       %img{:alt => "Edit on GitHub", "data-canonical-src" => "/images/edit.png", :src => "/images/edit.png", :style => "position: absolute; top: 0; right: 0; border: 0;"}


### PR DESCRIPTION
Show the 'edit on github' ribbon on events sub pages, just not on the index page.