### PR TITLE
RDO-Manager overhaul

### DIFF
--- a/source/rdo-manager/index.html.md
+++ b/source/rdo-manager/index.html.md
@@ -1,6 +1,6 @@
 ---
 title: RDO-Manager
-authors: athomas, hewbrocca, jcoufal, jistr, snecklifter
+authors: athomas, hewbrocca, jcoufal, jistr, snecklifter, trown
 wiki_title: RDO-Manager
 wiki_revision_count: 49
 wiki_last_updated: 2016-01-11
@@ -10,19 +10,44 @@ wiki_last_updated: 2016-01-11
 
 RDO-Manager is an OpenStack Deployment & Management tool for RDO. It is based on [OpenStack TripleO](http://wiki.openstack.org/wiki/TripleO) project and its philosophy is inspired by Spinal Stack project.
 
-RDO-Manager Architecture Overview: <http://www.rdoproject.org/RDO_Manager_Architecture_Overview>
+## Virtual Environment Quickstart
 
-RDO-Manager Components: <https://repos.fedorapeople.org/repos/openstack-m/rdo-manager-docs/liberty/introduction/components.html>
+There is a recent project called [tripleo-quickstart](https://github.com/redhat-openstack/tripleo-quickstart) whose main goal is to quickly stand up TripleO/RDO-Manager environments using an image based undercloud aproach similar to the [OPNFV Apex project](http://artifacts.opnfv.org/apex/docs/installation-instructions/).
 
-## Documentation
+You will need a host machine with at least 16G of RAM, preferably 32G,
+with CentOS 7 installed, and able to be ssh'd to without password from
+the machine running ansible.
 
-RDO-Manager User Guide: <https://repos.fedorapeople.org/repos/openstack-m/rdo-manager-docs/liberty/>
+The defaults are meant to "just work", so it is as easy as
+downloading and running the quickstart.sh script.
+This script will install this repo along with ansible in a
+virtual environment and run the quickstart playbook::
+
+    export VIRTHOST='my_test_machine.example.com'
+    bash <(curl -s https://raw.githubusercontent.com/redhat-openstack/tripleo-quickstart/master/quickstart.sh) [release]
+
+The playbook will output a debug message at the end with instructions
+to access the deployed undercloud. If a release name is not given, ``mitaka``
+is used.
+
+The install process is not run to completion so that it's easier to clean the
+image; to finish the installation, ssh into the undercloud VM and run::
+
+    openstack undercloud install
+
+as the ``stack`` user.
+
+Then proceed with the [upstream documentation](http://docs.openstack.org/developer/tripleo-docs/basic_deployment/basic_deployment_cli.html#upload-images) for the rest of the deployment.
+
+## Further Reading
+
+Upstream TripleO docs: <http://docs.openstack.org/developer/tripleo-docs/>
 
 > **Note:** Limit your environment specific content in the upper left corner of the documentation.
 
 [RDO-Manager troubleshooting](rdo-manager-troubleshooting)
 
-RDO-Manager with HA <https://remote-lab.net/rdo-manager-ha-openstack-deployment/>
+[Great blog on RDO-Manager HA setup](https://remote-lab.net/rdo-manager-ha-openstack-deployment/)
 
 ## Presentations
 


### PR DESCRIPTION
The RDO Manager documentation on the website is both
incomplete (it would be hard to get a working deploy
with what is there) and overly in depth (the
architechture section goes into details better handled
by upstream documentation).

Instead, this patch gives instructions to quickly stand
up a virtual deployment, and provides links to upstream
documentation for further reading.