### PR TITLE
Fix config parameter for ovs bridge_mappings

### DIFF
--- a/source/networking/neutron-with-existing-external-network.html.md
+++ b/source/networking/neutron-with-existing-external-network.html.md
@@ -50,7 +50,7 @@ This means, we will bring up the interface, and plug it into br-ex OVS bridge as
 
 Modify the following config parameter:
 
-    openstack-config --set /etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini ovs bridge_mappings extnet:br-ex
+    openstack-config --set /etc/neutron/plugins/ml2/openvswitch_agent.ini ovs bridge_mappings extnet:br-ex
 
 This will define a logical name for our external physical L2 segment, as "extnet", this will be referenced as a provider network when we create the external networks.
 


### PR DESCRIPTION
Hello, 

please update the config parameter for ovs bridge_mappings, because the config ```ovs_neutron_plugin.ini``` does not exist, anymore. 

This was already discussed at the [RDO mailing list](https://www.redhat.com/archives/rdo-list/2016-January/msg00014.html).

Kind regards, 
Dennis