### PR TITLE
wget might not be available, use curl -O instead

### DIFF
--- a/source/testday/mitaka/milestone3.html.md
+++ b/source/testday/mitaka/milestone3.html.md
@@ -54,8 +54,8 @@ Run the following commands as root.
 
   ```
   cd /etc/yum.repos.d/
-  wget http://trunk.rdoproject.org/centos7/delorean-deps.repo
-  wget http://trunk.rdoproject.org/centos7/current-passed-ci/delorean.repo
+  curl -O http://trunk.rdoproject.org/centos7/delorean-deps.repo
+  curl -O http://trunk.rdoproject.org/centos7/current-passed-ci/delorean.repo
   ```
 
 * Check for any [workarounds](/testday/mitaka/workarounds3) required for your platform before the main installation


### PR DESCRIPTION
wget has been deprecated in EL in favor of curl for ages, and it's not part of all installations anymore. There's no downside to using curl -O instead, so it's better to recommend it.