### PR TITLE
RDO Manager, and Reorg

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -79,6 +79,23 @@ hide_metadata: true
     .row
       .block-heading
         :markdown
+          ## Get Started
+
+          There's a few different ways to get started.
+
+          To spin up a proof of concept cloud on a single node, try an
+          all in one installation with the
+          [QuickStart](/install/quickstart).
+
+          If you want to create a production-ready cloud, you'll want to
+          use the [TripleO](/rdo-manager) quickstart guide.
+
+          And if you want to try out OpenStack without installing
+          anything, you want [TryStack](http://trystack.org/).
+
+    .row
+      .block-heading
+        :markdown
           ## Get Involved
 
           Want to update this documentation? Great! All you need is a GitHub account, then visit the link at the very middle bottom of each page, entitled "Edit this page on GitHub"

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -65,20 +65,6 @@ hide_metadata: true
     .row
       .block-heading
         :markdown
-          ## What is RDO?
-
-            {:.floatright.openstack-distro}
-            ![An Openstack Distribution](openstack-distribution.png)
-
-            RDO is a community of people using and deploying OpenStack on CentOS, Fedora, and Red Hat Enterprise Linux. We have [documentation to help get started](Docs), [Mailing lists](Mailing_lists) where you can connect with other users, and [community-supported packages](/install/quickstart/) of the most up-to-date OpenStack releases available for download.
-
-            If you are looking for enterprise-level support, or information on partner certification, Red Hat also offers [Red Hat Enterprise Linux OpenStack Platform](//redhat.com/openstack).
-
-            OpenStack relies on the underlying operating system and hypervisor — and what better operating system to build on than the industry's leading enterprise operating system? The RDO community is your one-stop community site for all things related to using OpenStack on Red Hat based platforms.
-
-    .row
-      .block-heading
-        :markdown
           ## Get Started
 
           There's a few different ways to get started.
@@ -92,6 +78,20 @@ hide_metadata: true
 
           And if you want to try out OpenStack without installing
           anything, you want [TryStack](http://trystack.org/).
+
+    .row
+      .block-heading
+        :markdown
+          ## What is RDO?
+
+            {:.floatright.openstack-distro}
+            ![An Openstack Distribution](openstack-distribution.png)
+
+            RDO is a community of people using and deploying OpenStack on CentOS, Fedora, and Red Hat Enterprise Linux. We have [documentation to help get started](Docs), [Mailing lists](Mailing_lists) where you can connect with other users, and [community-supported packages](/install/quickstart/) of the most up-to-date OpenStack releases available for download.
+
+            If you are looking for enterprise-level support, or information on partner certification, Red Hat also offers [Red Hat Enterprise Linux OpenStack Platform](//redhat.com/openstack).
+
+            OpenStack relies on the underlying operating system and hypervisor — and what better operating system to build on than the industry's leading enterprise operating system? The RDO community is your one-stop community site for all things related to using OpenStack on Red Hat based platforms.
 
     .row
       .block-heading


### PR DESCRIPTION
Removes RDO Manager from the front page, and moves a call to action up to the top.