### PR TITLE
handle the case where there's an event with no time

### DIFF
--- a/source/events/calendar.json.haml
+++ b/source/events/calendar.json.haml
@@ -28,7 +28,11 @@ index: false
 
           time_pool.compact!
 
-          current = time_pool.max.to_time > Time.now
+          if time_pool.max.nil?
+            current = false
+          else
+            current = time_pool.max.to_time > Time.now
+          end
 
           page = "/events/#{year_label}/"
 


### PR DESCRIPTION
rh-events recently had an event with no time; this patch fixes it where the calendar JSON info builds properly despite an event not having both a start and end times