### PR TITLE
Fix relative links to packaging sub-documents

### DIFF
--- a/source/documentation/packaging.html.md
+++ b/source/documentation/packaging.html.md
@@ -31,8 +31,8 @@ This process will be discussed and fleshed out in more detail on
 
 ### Packaging Guides
 
-* [RDO Packaging Guide](rdo-packaging)
-* [RDO Packaging Guidelines](rdo-packaging-guidelines)
+* [RDO Packaging Guide](../rdo-packaging)
+* [RDO Packaging Guidelines](../rdo-packaging-guidelines)
 * [`rdopkg` manual](/packaging/rdopkg/rdopkg.1.html)
 
 


### PR DESCRIPTION
Production website appends ending slash so
documentation/packaging.html.md ends up as
 rdoproject.org/documentation/packaging/ and relative links are rendered as
 rdoproject.org/documentation/packaging/rdo-packaging

FIXME ../ works around that but doesn't feel right, suggestions welcome!

@rbowen @garrett  @mscherer  ^