### PR TITLE
Documentation: point to newer packaging guides

### DIFF
--- a/source/documentation/index.html.md
+++ b/source/documentation/index.html.md
@@ -63,7 +63,7 @@ Since RDO sticks closely to the upstream OpenStack project, the documentation at
 
 ## Development
 
-* [Packaging Guides](/packaging)
+* [Packaging Guides](/documentation/packaging)
 * [Open
   Tickets](https://bugzilla.redhat.com/buglist.cgi?product=RDO&query_format=advanced&bug_status=NEW&bug_status=ASSIGNED)
 


### PR DESCRIPTION
Let's directly point to the newer packaging guides.