### PR TITLE
Extra / prevents the link from working

### DIFF
--- a/source/tripleo/index.html.md
+++ b/source/tripleo/index.html.md
@@ -55,7 +55,7 @@ Troubleshooting:
 
 TripleO (RDO-Manager) HA setup:
 
-*   [Great blog post on RDO-Manager HA setup](https://remote-lab.net/rdo-manager-ha-openstack-deployment/)
+*   [Great blog post on RDO-Manager HA setup](https://remote-lab.net/rdo-manager-ha-openstack-deployment)
 
 ## Presentations
 


### PR DESCRIPTION
The blog post about HA setup return 404 if the extra slash is there.