### PR TITLE
Don't mark external_network as shared

### DIFF
--- a/source/networking/neutron-with-existing-external-network.html.md
+++ b/source/networking/neutron-with-existing-external-network.html.md
@@ -74,7 +74,7 @@ or, alternatively:
 Now, create the external network with Neutron.
 
     # . keystonerc_admin
-    # neutron net-create external_network --provider:network_type flat --provider:physical_network extnet  --router:external --shared
+    # neutron net-create external_network --provider:network_type flat --provider:physical_network extnet  --router:external
 
 Please note: "extnet" is the L2 segment we defined with --os-neutron-ovs-bridge-mappings above.
 


### PR DESCRIPTION
I don't think it makes sense to have a network marked as external and as shared because this results in

* All projects and users can see the net and choose it on instance creation
* If a non-admin user does this, instance creation will fail because the user is not allowed to create a port in the net
* It is not required for creating a router and setting it as gateway as non-admin user