### PR TITLE
fixes & upgrades to create-post.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,6 @@ gem 'rails-assets-bootstrap-sortable'
 gem 'rails-assets-momentjs'
 gem 'rails-assets-fullcalendar'
 gem 'icalendar', '~> 1.5'
+
+gem 'slop', '~> 4'
+gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
     icalendar (1.5.4)
     json (1.8.2)
     kramdown (1.6.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     less (2.6.0)
       commonjs (~> 0.2.7)
     libv8 (3.16.14.7)
@@ -126,7 +128,7 @@ GEM
       rouge (~> 1.0)
     mini_portile (0.6.0)
     minitest (5.6.0)
-    multi_json (1.11.0)
+    multi_json (1.12.1)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
@@ -140,7 +142,7 @@ GEM
     padrino-support (0.12.5)
       activesupport (>= 3.1)
     ptools (1.3.2)
-    rack (1.6.0)
+    rack (1.6.4)
     rack-livereload (0.3.15)
       rack
     rack-test (0.6.3)
@@ -161,7 +163,8 @@ GEM
     ruby18_source_location (0.2)
     sass (3.4.13)
     sax-machine (1.3.1)
-    sprockets (2.12.3)
+    slop (4.3.0)
+    sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -212,6 +215,7 @@ DEPENDENCIES
   font-awesome-middleman
   icalendar (~> 1.5)
   kramdown
+  launchy
   less
   middleman (~> 3.3.10)
   middleman-blog
@@ -228,7 +232,11 @@ DEPENDENCIES
   rails-assets-jquery (~> 1)
   rails-assets-momentjs
   ruby18_source_location
+  slop (~> 4)
   stringex
   therubyracer
   wdm (~> 0.1.0)
   wikicloth
+
+BUNDLED WITH
+   1.10.6

--- a/create-post.rb
+++ b/create-post.rb
@@ -12,20 +12,25 @@ require 'slop'
 # Disable ActiveSupport's UTF-8 warning
 I18n.enforce_available_locales = false
 
-banner = 'Usage: ' + __FILE__ + ' [options] "Blog title here."'
+slop_opts = {
+  help: true,
+  ignore_case: true,
+  optional_arguments: true,
+  banner: 'Usage: ' + __FILE__ + ' [options] "Blog title here."'
+}
 
 # Command line options are parsed using Slop
-opts = Slop.parse!(help: true, ignore_case: true, banner: banner) do
-  on 'a', 'author', 'Author name', argument: :required, default: ENV['USER']
-  on 'd', 'date', 'Custom datetime', argument: :required, default: Time.now.strftime('%F %T %Z')
-  on 'e', 'editor', 'Custom editor', argument: :required, default: ENV['EDITOR']
-  on 't', 'tags', 'Comma-separated list of tags', argument: :required
-  on 'n', 'no-browser', 'Disable browser'
+opts = Slop.parse(slop_opts) do |o|
+  o.string '-a', '--author', 'Author name', argument: :required, default: ENV['USER']
+  o.string '-d', '--date', 'Custom datetime', argument: :required, default: Time.now.strftime('%F %T %Z')
+  o.string '-e', '--editor', 'Custom editor', argument: :required, default: ENV['EDITOR']
+  o.on '-t', '--tags', 'Comma-separated list of tags', argument: :required
+  o.on '-n', '--no-browser', 'Disable browser'
 end
 
-# Since we're using 'parse!', Slop removes the flags from ARGV,
+# Slop removes the flags from ARGV and places them in opts.arguments,
 # so we're left with the title (either as a string or in parts)
-title = ARGV.join(' ').strip
+title = opts.arguments.join(' ').strip
 
 # Simply display usage and exit if there's no title provided
 if title.empty?
@@ -69,7 +74,7 @@ if opts[:editor]
   exec opts[:editor], file_full
 else
   # Fall back to xdg-open (or platform equiv)
-  Launchy.open "#{file_full}"
+  Launchy.open file_full.to_s
 end
 
 # View file in a webpage

--- a/create-post.rb
+++ b/create-post.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/ruby
 
+require 'bundler'
+Bundler.setup
+
 require 'active_support/core_ext/string'
 require 'launchy'
 require 'yaml'


### PR DESCRIPTION
 Adds correct gems, upgrades `create-post.rb` to slop version 4, and enables one to run it without prefixing it with `bundle exec`

This should fix #578.