### PR TITLE
improved (ported) wiki link redirects

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -253,7 +253,7 @@ helpers do
         args[url_index].gsub!(/https?:\/\/(www.)?ovirt.org\//, '')
       end
 
-      if url.respond_to?('gsub') && url.respond_to?('match') && !url.match(/^http|^#|^\/\//)
+      if url.respond_to?('gsub') && url.respond_to?('match') && !url.match(/^http|^#|^\/\/|^\./)
         if url.match(/^(Special:|User:)/i)
           return "<span class='broken-link link-mediawiki' data-href='#{url}' title='Special MediaWiki link: original pointed to: #{url}'>#{args.first}</span>"
         end

--- a/config.rb
+++ b/config.rb
@@ -191,6 +191,9 @@ activate :site_helpers
 require 'lib/blog_helpers.rb'
 activate :blog_helpers
 
+require 'lib/wiki_helpers.rb'
+activate :wiki_helpers
+
 require 'lib/confcal.rb'
 activate :confcal
 
@@ -237,8 +240,6 @@ helpers do
     _image_tag(path, params)
   end
 
-  # WIP!!!
-
   # Monkeypatch Middleman's link_to to add missing page support
   # (and search MediaWiki imported files)
   def link_to(*args, &block)
@@ -252,30 +253,21 @@ helpers do
         args[url_index].gsub!(/https?:\/\/(www.)?ovirt.org\//, '')
       end
 
-      if url.respond_to?('gsub') && url.respond_to?('match') && !url.match(/^http|^#/)
-        p args if url.match(/Special:/)
-
+      if url.respond_to?('gsub') && url.respond_to?('match') && !url.match(/^http|^#|^\/\//)
         if url.match(/^(Special:|User:)/i)
-          # puts "WARNING: #{current_file}: Invalid link to '#{args[1]}'"
           return "<span class='broken-link link-mediawiki' data-href='#{url}' title='Special MediaWiki link: original pointed to: #{url}'>#{args.first}</span>"
         end
 
-        url_extra = ''
-
-        match = sitemap.resources.select do |resource|
-          extra = /[#\?].*/
-          url_extra = url.match(extra)
-          url_fixed = url.gsub(/_/, ' ').gsub(extra, '')
-          resource.data.wiki_title.to_s.downcase.strip == url_fixed.gsub(/_/, ' ').downcase.strip
-        end.sort_by { |r| File.stat(r.source_file).size }.reverse.first
-
-        args[url_index] = match.url + url_extra.to_s if match
+        match = find_wiki_page(url)
       end
+
+      args[url_index] = match if match
 
       result = _link_to(*args, &block)
 
-    rescue
-      puts "ERROR: #{current_file}: Issue with link to '#{args[1]}'"
+    rescue Exception => e
+      puts "WARNING: #{current_file}: Issue with link to '#{args[1]}'"
+      puts e.message
       return "<span class='broken-link link-error' data-href='#{url}' title='Broken link: original pointed to: #{url}'>#{args.first}</span>"
     end
 

--- a/lib/wiki_helpers.rb
+++ b/lib/wiki_helpers.rb
@@ -1,0 +1,81 @@
+# Various useful functions for Middleman-based sites
+class WikiHelpers < Middleman::Extension
+  def initialize(app, options_hash = {}, &block)
+    super
+  end
+
+  helpers do
+    def load_redirects
+      return $helper_wiki_redirects if $helper_wiki_redirects
+
+      slashes = /^\/|\/$/
+
+      redirects = File.readlines "#{root}/#{source}/redirects.yaml"
+
+      $helper_wiki_redirects ||= redirects.map do |line|
+        splits = line.split(': ')
+
+        {
+          from: splits.first.gsub(slashes, '').strip,
+          to: splits.last.gsub(slashes, '').strip
+        }
+      end.compact
+    end
+
+    def find_wiki_page(searchkey)
+      searchkey.sub!(/^ /, '#') # Handle a weird wiki-ism (space for hashes?)
+
+      # Regular expression to grab the extra bits at the end of a URL
+      extra = /[#\?].*/
+
+      # The extra stuff at the end of a URL,
+      # reformatted to use new hashes
+      url_extra = searchkey
+                  .match(extra).to_s
+                  .tr('_', '-').tr(' ', '-')
+                  .downcase.squeeze('-')
+
+      # The URL fragment, cleaned up and modified
+      url_fixed = searchkey
+                  .sub(extra, '').tr('_', ' ')
+                  .gsub(/^\/|\/$/, '')
+                  .downcase
+
+      # Processed redirects, filtered to requested page
+      match_redir = load_redirects.map do |redir|
+        next if url_fixed.empty?
+
+        exact_match = redir[:from].downcase == url_fixed
+        page_match = redir[:from].downcase.end_with?("/#{url_fixed}")
+
+        redir[:to].downcase.tr('_', ' ') if exact_match || page_match
+      end.compact
+
+      result = nil
+
+      # Find the matching page throughout the iste
+      sitemap.resources.each do |resource|
+        next unless resource.data.wiki_title
+
+        wiki_title = resource.data.wiki_title.to_s.downcase.strip
+
+        # Check direct matches
+        matches ||= wiki_title == url_fixed
+
+        # Handle redirects
+        matches ||= match_redir.include? wiki_title
+
+        # Return true if it matches, else it's false
+        if matches
+          result = resource.url + url_extra
+          break
+        end
+      end
+
+      # Return the URL with the extra hash
+      result
+    end
+  end
+end
+
+::Middleman::Extensions.register(:wiki_helpers, WikiHelpers)

--- a/source/testday/testedsetups.html.md
+++ b/source/testday/testedsetups.html.md
@@ -76,7 +76,7 @@ Please see [Deploying RDO Using Foreman](Deploying RDO Using Foreman) for direct
 
 | Config Name                          | Release    | BaseOS     | Status | HOWTO                                                                                                               | Who | Date | BZ/LP | Notes Page |
 |--------------------------------------|------------|------------|--------|---------------------------------------------------------------------------------------------------------------------|-----|------|-------|------------|
-| 2 Node install with Nova Networking  | Havana H-3 | RHEL 6.4   | ??     | [ 2 Node install with Nova Networking](Deploying_RDO_Using_Foreman #2_Node_install_with_Nova_Networking) | ??  | ??   | None  | None       |
+| 2 Node install with Nova Networking  | Havana H-3 | RHEL 6.4   | ??     | [ 2 Node install with Nova Networking](Deploying_RDO_Using_Foreman#2_Node_install_with_Nova_Networking) | ??  | ??   | None  | None       |
 |                                      |            | CentOS 6.4 | ??     | [ 2 Node install with Nova Networking](Deploying_RDO_Using_Foreman#2_Node_install_with_Nova_Networking)  | ??  | ??   | None  | None       |
 | 3 Node install with Neutron          | Havana H-3 | RHEL 6.4   | ??     | [ 3 Node install with Neutron](Deploying_RDO_Using_Foreman#Neutron_with_Networker_Node)                  | ??  | ??   | None  | None       |
 |                                      |            | CentOS 6.4 | ??     | [ 3 Node install with Neutron](Deploying_RDO_Using_Foreman#Neutron_with_Networker_Node)                  | ??  | ??   | None  | None       |


### PR DESCRIPTION
Ported wiki link redirect modifications now redirect in resulting HTML, instead of relying on Apache redirect rules. (Reference PR from oVirt: https://github.com/oVirt/ovirt-site/pull/285)

See https://github.com/garrett/TEMP-rdo-wikilink-changes/compare/first...master to view a rich-diff comparison of HTML output for exactly what this patch will do for the RDO website.