### PR TITLE
Remove non-breaking spaces from commands and config samples

### DIFF
--- a/source/api/tuskar-api.html.md
+++ b/source/api/tuskar-api.html.md
@@ -13,109 +13,109 @@ wiki_last_updated: 2015-01-23
 
 Example of JSON Representation of Plan
 
-         {
-           "created_at": "2014-09-26T20:23:14.222815",
-           "description": "Development testing cloud",
-           "name": "dev-cloud",
-           "parameters":
-           [
-             {
-               "default": "guest",
-               "description": "The password for RabbitMQ",
-               "hidden": true,
-               "label": null,
-               "name": "compute-1::RabbitPassword",
-               "value": "secret-password"
-             }
-           ],
-           "roles":
-           [
-             {
-               "description": "OpenStack hypervisor node. Can be wrapped in a ResourceGroup for scaling.\n",
-               "name": "compute",
-               "uuid": "b7b1583c-5c80-481f-a25b-708ed4a39734",
-               "version": 1
-             }
-           ],
-           "updated_at": null,
-           "uuid": "53268a27-afc8-4b21-839f-90227dd7a001"
-         }
+         {
+           "created_at": "2014-09-26T20:23:14.222815",
+           "description": "Development testing cloud",
+           "name": "dev-cloud",
+           "parameters":
+           [
+             {
+               "default": "guest",
+               "description": "The password for RabbitMQ",
+               "hidden": true,
+               "label": null,
+               "name": "compute-1::RabbitPassword",
+               "value": "secret-password"
+             }
+           ],
+           "roles":
+           [
+             {
+               "description": "OpenStack hypervisor node. Can be wrapped in a ResourceGroup for scaling.\n",
+               "name": "compute",
+               "uuid": "b7b1583c-5c80-481f-a25b-708ed4a39734",
+               "version": 1
+             }
+           ],
+           "updated_at": null,
+           "uuid": "53268a27-afc8-4b21-839f-90227dd7a001"
+         }
 
 ### List All Plans
 
-`   curl -v -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' `[`http://0.0.0.0:8585/v2/plans/`](http://0.0.0.0:8585/v2/plans/)
+`   curl -v -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' `[`http://0.0.0.0:8585/v2/plans/`](http://0.0.0.0:8585/v2/plans/)
 
 ### Retrieve a Single Plan
 
-`   curl -v -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' `[`http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001`](http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001)
+`   curl -v -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' `[`http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001`](http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001)
 
 ### Create a New Plan
 
-         curl -v -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d  '
-          {
-            "name": "dev-cloud",
-            "description": "Development testing cloud",
-          }
-`    ' `[`http://0.0.0.0:8585/v2/plans`](http://0.0.0.0:8585/v2/plans)
+         curl -v -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d  '
+          {
+            "name": "dev-cloud",
+            "description": "Development testing cloud",
+          }
+`    ' `[`http://0.0.0.0:8585/v2/plans`](http://0.0.0.0:8585/v2/plans)
 
 This command will create new Plan without any Roles associated with it. To assign a Role to Plan see 'How to Add a Role to a Plan'.
 
 ### Delete an Existing Plan
 
-`   curl -v -X DELETE `[`http://localhost:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001`](http://localhost:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001)
+`   curl -v -X DELETE `[`http://localhost:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001`](http://localhost:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001)
 
 ### Changing a Plan’s Configuration Values
 
-         curl -v -X PATCH -H 'Content-Type: application/json' -H 'Accept: application/json' -d '
-         [
-           {
-             "name" : "database_host",
-             "value" : "10.11.12.13"
-           },
-           {
-             "name" : "database_password",
-             "value" : "secret"
-           }
-         ]
-`   ' `[`http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001`](http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001)
+         curl -v -X PATCH -H 'Content-Type: application/json' -H 'Accept: application/json' -d '
+         [
+           {
+             "name" : "database_host",
+             "value" : "10.11.12.13"
+           },
+           {
+             "name" : "database_password",
+             "value" : "secret"
+           }
+         ]
+`   ' `[`http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001`](http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001)
 
 You can change only existing parameters in Plan.
 
 ### Retrieve a Plan’s Template Files
 
-`   curl -v -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' `[`http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001/templates`](http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001/templates)
+`   curl -v -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' `[`http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001/templates`](http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001/templates)
 
 Example of JSON representation:
 
-         {
-           "environment.yaml" : "... content of template file ...",
-           "plan.yaml" : "... content of template file ...",
-           "provider-compute-1.yaml" : "... content of template file ..."
-         }
+         {
+           "environment.yaml" : "... content of template file ...",
+           "plan.yaml" : "... content of template file ...",
+           "provider-compute-1.yaml" : "... content of template file ..."
+         }
 
 ## Role
 
 Example of JSON Representation of Role
 
-         {
-           "description": "OpenStack hypervisor node. Can be wrapped in a ResourceGroup for scaling.\n",
-           "name": "compute",
-           "uuid": "b7b1583c-5c80-481f-a25b-708ed4a39734",
-           "version": 1
-         }
+         {
+           "description": "OpenStack hypervisor node. Can be wrapped in a ResourceGroup for scaling.\n",
+           "name": "compute",
+           "uuid": "b7b1583c-5c80-481f-a25b-708ed4a39734",
+           "version": 1
+         }
 
 ### Retrieving Possible Roles
 
-`   curl -v -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' `[`http://0.0.0.0:8585/v2/roles/`](http://0.0.0.0:8585/v2/roles/)
+`   curl -v -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' `[`http://0.0.0.0:8585/v2/roles/`](http://0.0.0.0:8585/v2/roles/)
 
 ### Adding a Role to a Plan
 
-         curl -v -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d  '
-          {
-            "uuid": "b7b1583c-5c80-481f-a25b-708ed4a39734"
-          }
-`    ' `[`http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001`](http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001)
+         curl -v -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d  '
+          {
+            "uuid": "b7b1583c-5c80-481f-a25b-708ed4a39734"
+          }
+`    ' `[`http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001`](http://0.0.0.0:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001)
 
 ### Removing a Role from a Plan
 
-`   curl -v -X DELETE `[`http://localhost:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001/roles/b7b1583c-5c80-481f-a25b-708ed4a39734`](http://localhost:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001/roles/b7b1583c-5c80-481f-a25b-708ed4a39734)
+`   curl -v -X DELETE `[`http://localhost:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001/roles/b7b1583c-5c80-481f-a25b-708ed4a39734`](http://localhost:8585/v2/plans/53268a27-afc8-4b21-839f-90227dd7a001/roles/b7b1583c-5c80-481f-a25b-708ed4a39734)

--- a/source/documentation/editing.html.md
+++ b/source/documentation/editing.html.md
@@ -21,9 +21,9 @@ More help pages on using MediaWiki are linked on [MediaWiki's help pages](https:
 
 To post long lines, such as log output or script lines, wrap a block in
 
-         <pre style="white-space: pre; overflow-x: auto; word-wrap: normal">
-             ...
-         </pre>
+         <pre style="white-space: pre; overflow-x: auto; word-wrap: normal">
+             ...
+         </pre>
 
 The site is set up to use Kramdown, which is a featureful version of
 Markdown. It mirrors GitHub's settings and then a few

--- a/source/documentation/enabling-migrations.html.md
+++ b/source/documentation/enabling-migrations.html.md
@@ -14,48 +14,48 @@ Migration support in Nova allows the relocation of instances to different comput
 
 The arguably safer and less-complicated mechanism of an offline migration is purely instrumented by nova and is relatively easy to set up. Simply create and distribute password-less SSH keys for the "nova" user, starting on one of the nodes:
 
-      # su -s /bin/bash nova
-      $ ssh-keygen
-      Generating public/private rsa key pair.
-      Enter passphrase (empty for no passphrase): 
-      Enter same passphrase again: 
-      Your identification has been saved in id_rsa.
-      Your public key has been saved in id_rsa.pub.
-      The key fingerprint is:
-      56:1d:13:c5:3c:fd:93:01:fa:66:68:38:48:73:24:5c dan@compute1
-      The key's randomart image is:
-      +--[ RSA 2048]----+
-      |      ...E  +*o. |
-      |       .o  ..o+..|
-      |       o ....  .+|
-      |      . +.. o  o.|
-      |       .So o +  .|
-      |       .  o o    |
-      |                 |
-      |                 |
-      |                 |
+      # su -s /bin/bash nova
+      $ ssh-keygen
+      Generating public/private rsa key pair.
+      Enter passphrase (empty for no passphrase): 
+      Enter same passphrase again: 
+      Your identification has been saved in id_rsa.
+      Your public key has been saved in id_rsa.pub.
+      The key fingerprint is:
+      56:1d:13:c5:3c:fd:93:01:fa:66:68:38:48:73:24:5c dan@compute1
+      The key's randomart image is:
+      +--[ RSA 2048]----+
+      |      ...E  +*o. |
+      |       .o  ..o+..|
+      |       o ....  .+|
+      |      . +.. o  o.|
+      |       .So o +  .|
+      |       .  o o    |
+      |                 |
+      |                 |
+      |                 |
       +-----------------+
 
 This key needs to be authorized to log in as nova, so we need to put it into the authorized_keys list:
 
-      $ cat .ssh/id_rsa.pub >> .ssh/authorized_keys
-      $ chmod 600 .ssh/authorized_keys
+      $ cat .ssh/id_rsa.pub >> .ssh/authorized_keys
+      $ chmod 600 .ssh/authorized_keys
 
 Next, we need to build a known_hosts file with the host key of every compute node (including this one:
 
-      ssh-keyscan compute1 compute2 compute3 compute4 > ~/.ssh/known_hosts
+      ssh-keyscan compute1 compute2 compute3 compute4 > ~/.ssh/known_hosts
 
 Now, we need to distribute the entire .ssh directory to all the rest of the hosts. If you used something like packstack and already have root ssh key authentication set up, then you can do this as root:
 
-      for host in compute1 compute2 compute3 compute4; do
-          tar cf - ~nova/.ssh | ssh $host "cd /; tar xf -"
+      for host in compute1 compute2 compute3 compute4; do
+          tar cf - ~nova/.ssh | ssh $host "cd /; tar xf -"
       done
 
 To test that this is working, try ssh'ing from one compute node to another as the nova user:
 
-      # su -s /bin/bash nova
-      $ ssh compute2 "echo It worked!"
-      It worked!
+      # su -s /bin/bash nova
+      $ ssh compute2 "echo It worked!"
+      It worked!
       $
 
 In case you get a "This account is currently not available." error, you will need to enable logins to the "nova" user with:
@@ -72,18 +72,18 @@ At this point, you should be able to use the offline migration and resize comman
 
 Enabling live migration of instances is a little more complicated than the process for offline migrations, but it shares a lot of the same setup steps. Since live migrations are orchestrated by libvirt instead of nova, the private key must be installed for the root user (libvirt runs as root) instead of (or in addition to) the nova user. To start, follow the offline instructions above, but install the id_rsa private key for the root user on each compute node. If you used packstack or some other tool to install your deployment, this may already be done for you. The test is that you must be able to run this from any compute node to any other compute node, without being asked to approve a host key or type in a password:
 
-      # id -u
+      # id -u
       0
-      # ssh compute2 "It works!"
-      It works!
+      # ssh compute2 "It works!"
+      It works!
       #
 
 The first additional step you need to take is to configure nova on the compute nodes to not bind vnc consoles to the IP of the compute node. Without this, migrations will fail because the receiving compute node will not be able to bind to the address of the sending one. In /etc/nova/nova.conf, set the bind address to any:
 
-      vncserver_listen = 0.0.0.0
+      vncserver_listen = 0.0.0.0
 
 Next, you need to configure the firewall to not block libvirt ephemeral ports used during live migration:
 
-      iptables -I INPUT -p tcp --dport 49152:49215 -j ACCEPT
+      iptables -I INPUT -p tcp --dport 49152:49215 -j ACCEPT
 
 Once this is done, you should be able to live-migrate instances from one host to the other.

--- a/source/documentation/keystone-integration-with-idm.html.md
+++ b/source/documentation/keystone-integration-with-idm.html.md
@@ -722,20 +722,20 @@ You can secure qpidd with either Kerberos or SSL, but not both. Securing with Ke
 
 <!-- -->
 
-    [admin@ipa01]$ ipa service-add qpidd/openstack.example.com
+    [admin@ipa01]$ ipa service-add qpidd/openstack.example.com
 
 *   Retrieve a keytab for this new service
 
 <!-- -->
 
-    [root@openstack]# ipa-getkeytab -s ipa01.example.com -k /etc/qpidd.keytab -p qpidd/openstack.example.com
+    [root@openstack]# ipa-getkeytab -s ipa01.example.com -k /etc/qpidd.keytab -p qpidd/openstack.example.com
 
 *   Fix permissions and ownership of the keytab
 
 <!-- -->
 
-    [root@openstack]# chown qpidd /etc/qpidd.keytab
-    [root@openstack]# chmod 600 /etc/qpidd.keytab
+    [root@openstack]# chown qpidd /etc/qpidd.keytab
+    [root@openstack]# chmod 600 /etc/qpidd.keytab
 
 *   Configure qpidd by setting auth and realm in `/etc/qpidd.conf`
 
@@ -748,7 +748,7 @@ You can secure qpidd with either Kerberos or SSL, but not both. Securing with Ke
 
 <!-- -->
 
-    mech_list: GSSAPI
+    mech_list: GSSAPI
 
 *   Create the file `/etc/sysconfig/qpidd` to tell qpidd the location of its Kerberos keytab:
 
@@ -772,13 +772,13 @@ You can secure qpidd with either Kerberos or SSL, but not both. Securing with Ke
 
 <!-- -->
 
-    [root@openstack]# service qpidd restart
+    [root@openstack]# service qpidd restart
 
 *   `/var/log/messages` should be complaining now about cinder and nova
 
 <!-- -->
 
-    ERROR [cinder.openstack.common.rpc.impl_qpid] Unable to connect to AMQP server: Error in sasl_client_start (-1) SASL(-1): generic failure: GSSAPI Error: Unspecified GSS failure.  Minor code may provide more information (Cannot determine realm for numeric host address).
+    ERROR [cinder.openstack.common.rpc.impl_qpid] Unable to connect to AMQP server: Error in sasl_client_start (-1) SASL(-1): generic failure: GSSAPI Error: Unspecified GSS failure.  Minor code may provide more information (Cannot determine realm for numeric host address).
 
 *   Configure nova to use a DNS name instead of an IP address in `/etc/nova/nova.conf`
 
@@ -796,70 +796,70 @@ You can secure qpidd with either Kerberos or SSL, but not both. Securing with Ke
 
 <!-- -->
 
-    [root@openstack]# service openstack-cinder-api restart
-    [root@openstack]# service openstack-cinder-scheduler restart 
-    [root@openstack]# service openstack-cinder-volume restart 
-    [root@openstack]# service openstack-nova-api restart
-    [root@openstack]# service openstack-nova-cert restart
-    [root@openstack]# service openstack-nova-compute restart
-    [root@openstack]# service openstack-nova-conductor restart
-    [root@openstack]# service openstack-nova-consoleauth restart
-    [root@openstack]# service openstack-nova-network restart
-    [root@openstack]# service openstack-nova-novncproxy restart
+    [root@openstack]# service openstack-cinder-api restart
+    [root@openstack]# service openstack-cinder-scheduler restart 
+    [root@openstack]# service openstack-cinder-volume restart 
+    [root@openstack]# service openstack-nova-api restart
+    [root@openstack]# service openstack-nova-cert restart
+    [root@openstack]# service openstack-nova-compute restart
+    [root@openstack]# service openstack-nova-conductor restart
+    [root@openstack]# service openstack-nova-consoleauth restart
+    [root@openstack]# service openstack-nova-network restart
+    [root@openstack]# service openstack-nova-novncproxy restart
 
 *   Now if you look in `/var/log/messages` there should be errors about a missing credentials cache:
 
 <!-- -->
 
-    GSSAPI Error: Unspecified GSS failure.  Minor code may provide more information (Credentials cache file '/tmp/krb5cc_162' not found)
+    GSSAPI Error: Unspecified GSS failure.  Minor code may provide more information (Credentials cache file '/tmp/krb5cc_162' not found)
 
 *   Create an IPA service for nova and cinder
 
 <!-- -->
 
-    [admin@ipa01]$ ipa service-add nova/openstack.example.com
-    [admin@ipa01]$ ipa service-add cinder/openstack.example.com
+    [admin@ipa01]$ ipa service-add nova/openstack.example.com
+    [admin@ipa01]$ ipa service-add cinder/openstack.example.com
 
 *   Get the uid for nova and cinder
 
 <!-- -->
 
-    [root@openstack]# id nova
-    uid=162(nova) gid=162(nova) groups=162(nova),99(nobody),107(qemu)
-    [root@openstack# id cinder
-    uid=165(cinder) gid=165(cinder) groups=165(cinder),99(nobody)
+    [root@openstack]# id nova
+    uid=162(nova) gid=162(nova) groups=162(nova),99(nobody),107(qemu)
+    [root@openstack]# id cinder
+    uid=165(cinder) gid=165(cinder) groups=165(cinder),99(nobody)
 
 *   Create a keytab for nova
 
 <!-- -->
 
-    [root@openstack#  ipa-getkeytab -s ipa01.example.com -k /etc/nova.keytab -p nova/openstack.example.com
+    [root@openstack]#  ipa-getkeytab -s ipa01.example.com -k /etc/nova.keytab -p nova/openstack.example.com
 
 *   Create a keytab for cinder
 
 <!-- -->
 
-    [root@openstack#  ipa-getkeytab -s ipa01.example.com -k /etc/cinder.keytab -p cinder/openstack.example.com
+    [root@openstack]#  ipa-getkeytab -s ipa01.example.com -k /etc/cinder.keytab -p cinder/openstack.example.com
 
 *   Create a credentials cache for nova using the id for the nova user
 
 <!-- -->
 
-    [root@openstack# kinit -k /etc/nova.keytab -c /tmp/krb5cc_162 nova/openstack.example.com
-    [root@openstack# chown nova /tmp/krb5cc_162
+    [root@openstack]# kinit -k /etc/nova.keytab -c /tmp/krb5cc_162 nova/openstack.example.com
+    [root@openstack]# chown nova /tmp/krb5cc_162
 
 *   Create a credentials cache for cinder using the id for the cinder user
 
 <!-- -->
 
-    [root@openstack# kinit -k /etc/cinder.keytab -c /tmp/krb5cc_165 cinder/openstack.example.com
-    [root@openstack# chown cinder /tmp/krb5cc_165
+    [root@openstack]# kinit -k /etc/cinder.keytab -c /tmp/krb5cc_165 cinder/openstack.example.com
+    [root@openstack]# chown cinder /tmp/krb5cc_165
 
 *   Restart qpidd again to force a reconnection attempt
 
 <!-- -->
 
-    [root@openstack]# service qpidd restart
+    [root@openstack]# service qpidd restart
 
 The GSSAPI errors should be gone, nova and cinder are now using Kerberos for authentication and encryption.
 
@@ -867,9 +867,9 @@ The problem with this is that the key we just obtained is only good for a specif
 
 The fix for now is to create a cron job which will renew these credentials.
 
-      [root@openstack]# crontab -e
-      1 0,6,12,18 * * * su - nova -c "kinit nova/openstack.example.com -kt /etc/nova.keytab -c /tmp/krb5cc_162"
-      1 0,6,12,18 * * * su - cinder -c "kinit cinder/openstack.example.com -kt /etc/cinder.keytab -c /tmp/krb5cc_165"
+      [root@openstack]# crontab -e
+      1 0,6,12,18 * * * su - nova -c "kinit nova/openstack.example.com -kt /etc/nova.keytab -c /tmp/krb5cc_162"
+      1 0,6,12,18 * * * su - cinder -c "kinit cinder/openstack.example.com -kt /etc/cinder.keytab -c /tmp/krb5cc_165"
 
 ## Securing Keystone
 

--- a/source/documentation/packstack-cookbook.html.md
+++ b/source/documentation/packstack-cookbook.html.md
@@ -15,25 +15,25 @@ page](https://wiki.openstack.org/wiki/Packstack).
 
 #### Help
 
-         packstack --help
+         packstack --help
 
 #### All in one
 
-         packstack --allinone
+         packstack --allinone
 
 Shorthand for
 
-         --install-hosts=<local ipaddr> --novanetwork-pubif=<dev> --novacompute-privif=lo --novanetwork-privif=lo --os-swift-install=y --nagios--install=y
+         --install-hosts=<local ipaddr> --novanetwork-pubif=<dev> --novacompute-privif=lo --novanetwork-privif=lo --os-swift-install=y --nagios--install=y
 
 This option can be used to install an all in one OpenStack on this host.
 
 #### Generate answer file
 
-         packstack --gen-answer-file
+         packstack --gen-answer-file
 
 Any other command line options may be provided with this one, to produce a reusable answer file.
 
 #### Reuse an answer file
 
-         packstack --answer-file=/path/to/packstack_answers.txt
+         packstack --answer-file=/path/to/packstack_answers.txt
 

--- a/source/documentation/repositories.html.md
+++ b/source/documentation/repositories.html.md
@@ -16,9 +16,9 @@ This document expands on the details of the various repositories involved.
 
 If using RHEL it's assumed that `rhel-7-server-rpms` is enabled by default. RDO also needs the `Optional`, `Extras`, and `RH Common` channels to be enabled:
 
-    $ sudo subscription-manager repos --enable rhel-7-server-optional-rpms
+    $ sudo subscription-manager repos --enable rhel-7-server-optional-rpms
 
-    $ sudo subscription-manager repos --enable rhel-7-server-extras-rpms
+    $ sudo subscription-manager repos --enable rhel-7-server-extras-rpms
 
     $ sudo subscription-manager repos --enable=rhel-7-server-rh-common-rpms
 

--- a/source/documentation/securing-services.html.md
+++ b/source/documentation/securing-services.html.md
@@ -34,25 +34,25 @@ Note that this example uses 192.168.200.x as the OpenStack private network for e
 
 Ensure the hostname of your IPA server is the FQDN on the private network:
 
-      echo "$(hostname -s).openstack.priv" > /etc/hostname
-      echo "$(hostname -i) $(hostname -s).openstack.priv" >> /etc/hosts
-      sed -i "s/^`\(HOSTNAME=\)`.*$/\1$(hostname -s).openstack.priv/" \
-         /etc/sysconfig/network
-         hostname $(hostname -s).openstack.priv
+      echo "$(hostname -s).openstack.priv" > /etc/hostname
+      echo "$(hostname -i) $(hostname -s).openstack.priv" >> /etc/hosts
+      sed -i "s/^`\(HOSTNAME=\)`.*$/\1$(hostname -s).openstack.priv/" \
+         /etc/sysconfig/network
+         hostname $(hostname -s).openstack.priv
 
 Instal the IPA server:
 
-      yum install freeipa-server bind bind-dyndb-ldap
-      ipa-server-install --setup-dns --forwarder=192.168.200.1 \
-        --hostname=$(hostname -s).openstack.priv -r OPENSTACK.PRIV \
-        -n openstack.priv -p Secret123 -P Secret123 -a Secret123 -U
+      yum install freeipa-server bind bind-dyndb-ldap
+      ipa-server-install --setup-dns --forwarder=192.168.200.1 \
+        --hostname=$(hostname -s).openstack.priv -r OPENSTACK.PRIV \
+        -n openstack.priv -p Secret123 -P Secret123 -a Secret123 -U
 
 Verify the IP for the subnet you are using (192.168.200.1, in our example), is in /etc/resolv.conf.
 
 Create your controller host entry:
 
-      ipa dnsrecord-add openstack.priv v3controller --a-rec=192.168.200.10
-       --a-create-reverse
+      ipa dnsrecord-add openstack.priv v3controller --a-rec=192.168.200.10
+       --a-create-reverse
 
 #### On OpenStack Controller
 
@@ -60,12 +60,12 @@ Make sure the ipa server is in resolv.conf (listed first)
 
 Install and configure the IPA client software. If you are using the IPA DNS then the domain and server will be autodiscovered. For authentication you can use the IPA admin user and password.
 
-      yum install ipa-client
+      yum install ipa-client
       ipa-client-install
 
 If you have dhclient running on your machine(s), you will also want to update the config in /etc/dhcp/dhclient-<nic>.conf to have the line:
 
-      option domain-name-servers 192.168.200.1, `<domain-server-ip-2>`, `<etc>`;
+      option domain-name-servers 192.168.200.1, `<domain-server-ip-2>`, `<etc>`;
 
 Otherwise dhclient will overwrite /etc/resolv.conf causing DNS resolution to fail.
 
@@ -156,7 +156,7 @@ Configuring qpidd does not currently work without making some manual changes, de
 
 *   Install the qpid-cpp-server-ssl package
 
-      # yum install qpid-cpp-server-ssl
+      # yum install qpid-cpp-server-ssl
 
 *   Create a directory to store the NSS certificate database for qpidd
 
@@ -227,15 +227,15 @@ To manually configure the horizon/dashboard service you will need to obtain an S
 
 *   Install the mod_ssl package
 
-      # yum install mod_ssl
+      # yum install mod_ssl
 
 *   Modify /etc/httpd/conf/httpd.conf and add
 
-      Listen 0.0.0.0:443
-      SSLEngine on
-      SSLCertificateKeyFile /path/to/server.key
-      SSLCertificateFile /path/to/server.crt
-      SSLCertificateCAFile /path/to/ca.crt
+      Listen 0.0.0.0:443
+      SSLEngine on
+      SSLCertificateKeyFile /path/to/server.key
+      SSLCertificateFile /path/to/server.crt
+      SSLCertificateCAFile /path/to/ca.crt
 
 *   Restart httpd
 
@@ -243,8 +243,8 @@ Some care is needed depending on your configuration. You may already have a defa
 
 You can optionally remove the listener on port 80, or always forward requests made on the non-secure port to the secure port by adding this to your configuration file and restarting httpd:
 
-      RewriteEngine On
-      RewriteCond %{HTTPS} !=on
-      RewriteRule ^/?(.*) `[`https://`](https://)`%{SERVER_NAME}/$1 [R,L]
+      RewriteEngine On
+      RewriteCond %{HTTPS} !=on
+      RewriteRule ^/?(.*) `[`https://`](https://)`%{SERVER_NAME}/$1 [R,L]
 
 Automating this configuration relies on upstream patch <https://review.openstack.org/49799> . The current horizon puppet module includes a listen_ssl option which makes Apache listen on port 443 but it doesn't require the mod_ssl package or enable the other SSL configuration options.

--- a/source/documentation/tunings-and-tweaks.html.md
+++ b/source/documentation/tunings-and-tweaks.html.md
@@ -14,43 +14,43 @@ This page has been created to track changes to the underlying systems and the de
 
 You will hit OS system limits as you scale (this is a big hammer, will need some tightening for security) Increase number of open files on the messing and database services (EL6) edit /etc/security/limits.conf:
 
-         mysql    soft nofile 16384
-         mysql   hard nofile 16384
-         qpidd   soft nofile 16384
-         qpidd   hard nofile 16384
-         rabbitmq   soft nofile 16384
-         rabbitmq  hard nofile 16384
-         postgres soft nofile 16384
-         postgres hard nofile 16384
-         Increase number of procs
-         /etc/security/limits.d/90-nproc.conf
-         *          soft    nproc     10240
-         root       soft    nproc     unlimited
+         mysql    soft nofile 16384
+         mysql   hard nofile 16384
+         qpidd   soft nofile 16384
+         qpidd   hard nofile 16384
+         rabbitmq   soft nofile 16384
+         rabbitmq  hard nofile 16384
+         postgres soft nofile 16384
+         postgres hard nofile 16384
+         Increase number of procs
+         /etc/security/limits.d/90-nproc.conf
+         *          soft    nproc     10240
+         root       soft    nproc     unlimited
 
 Systemd (EL7, Fedora) uses per service limits and does not uses /etc/security/limits.conf . One possible way for setting a per service limit is creating a new service target in the /etc/systemd/system/ which will inherit and override from the packaged version of the target.
 
 /etc/systemd/system/rabbitmq-server.service:
 
-       .include /lib/systemd/system/rabbitmq-server.service
-       [Service]
-        LimitNOFILE=16384
+       .include /lib/systemd/system/rabbitmq-server.service
+       [Service]
+        LimitNOFILE=16384
 
 Instead of creating an overlapping service, just extending it is also possible:
 
       /etc/systemd/system/mariadb.service.d/limits.conf
       [Service]
-      LimitNOFILE = 16384
+      LimitNOFILE = 16384
 
 If the service already enabled and the service link points to the packaged version of the script, you need to disable and enable the service:
 
-       systemctl  stop rabbitmq-server
-       systemctl disable rabbitmq-server
-       systemctl enable rabbitmq-server
-       systemctl  start rabbitmq-server
+       systemctl  stop rabbitmq-server
+       systemctl disable rabbitmq-server
+       systemctl enable rabbitmq-server
+       systemctl  start rabbitmq-server
 
 The systemd config files need to be reload after configuration changes:
 
-       systemctl daemon-reload
+       systemctl daemon-reload
 
 HAProxy requires to configure the file descriptor limits inside it's config file. <http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#3.2-maxconn>
 
@@ -58,80 +58,80 @@ By default lots of stuff seems to go to /var, if possible put /var on a bigger, 
 
 **Neutron**
 
-          to increase the number of networks and similar components you can run this from the command line
+          to increase the number of networks and similar components you can run this from the command line
 
-         where tenant-id is the uuid of the openstack tenant running the test
+         where tenant-id is the uuid of the openstack tenant running the test
 
-         neutron quota-update  --tenant-id  $admin  --network -1 --subnet  -1 --port  -1 --router -1 --floatingip -1 --security_group -1 --security_group_rule -1
-         # add --vip -1 --pool -1  if needed
-        The -1 means unlimited.
+         neutron quota-update  --tenant-id  $admin  --network -1 --subnet  -1 --port  -1 --router -1 --floatingip -1 --security_group -1 --security_group_rule -1
+         # add --vip -1 --pool -1  if needed
+        The -1 means unlimited.
 
-         Use jumbo frames for interfaces carrying GRE/VXLAN traffic:
-         Compute node(s):
-`      echo MTU=`<MTU>` >> /etc/sysconfig/network-scripts/ifcfg-`<interface>
-            network_device_mtu=`<Guest MTU>` (50b less than tunnel interface for vxaln, 28b less for gre ) in the nova.conf file 
-         Network node(s):
-`      echo MTU=`<MTU>` >> /etc/sysconfig/network-scripts/ifcfg-`<interface>
-            echo dnsmasq_config_file=/etc/neutron/dnsmasq-neutron.conf >> /etc/neutron/dhcp_agent.ini
-            echo dhcp-option-force=26,`<MTU>` >> /etc/neutron/dnsmasq-neutron.conf
-         Disable secure rootwrap:
-         Change root_helper in /etc/neutron/neutron.conf and in all used neutron ini file.
-             [agent]
-             root_helper = sudo
-         Edit the sudores file to allow neutron to use sudo without password for the commands required by neutron.
-         It makes the command execution faster, but without filtering it is less secure.
-         Just by the sudoers files you cannot property filter an evil command patters like this: ip netns exec net-ns evil_command. 
+         Use jumbo frames for interfaces carrying GRE/VXLAN traffic:
+         Compute node(s):
+`      echo MTU=`<MTU>` >> /etc/sysconfig/network-scripts/ifcfg-`<interface>
+            network_device_mtu=`<Guest MTU>` (50b less than tunnel interface for vxaln, 28b less for gre ) in the nova.conf file 
+         Network node(s):
+`      echo MTU=`<MTU>` >> /etc/sysconfig/network-scripts/ifcfg-`<interface>
+            echo dnsmasq_config_file=/etc/neutron/dnsmasq-neutron.conf >> /etc/neutron/dhcp_agent.ini
+            echo dhcp-option-force=26,`<MTU>` >> /etc/neutron/dnsmasq-neutron.conf
+         Disable secure rootwrap:
+         Change root_helper in /etc/neutron/neutron.conf and in all used neutron ini file.
+             [agent]
+             root_helper = sudo
+         Edit the sudores file to allow neutron to use sudo without password for the commands required by neutron.
+         It makes the command execution faster, but without filtering it is less secure.
+         Just by the sudoers files you cannot property filter an evil command patters like this: ip netns exec net-ns evil_command. 
 
 **Compute node**
 
-         Ensure tuned is in place 
+         Ensure tuned is in place 
 
-         tuned-adm list
+         tuned-adm list
 
 **\1**
 
-         There is a limit to how many rows get returned from queries
+         There is a limit to how many rows get returned from queries
 
-         /etc/nova/nova.conf
+         /etc/nova/nova.conf
 
-         osapi_max_limit=10000
+         osapi_max_limit=10000
 
-         Increase defaults for mysql
+         Increase defaults for mysql
 
-            increase number of connections -
+            increase number of connections -
 
 in /etc/my.cnf
 
-         max_connections = 15360
-         innodb_buffer_pool_size = 10G
-         innodb_flush_method = O_DIRECT
-         innodb_file_per_table
-         innodb_flush_log_at_trx_commit = 0
-         innodb_log_file_size=1500M
-         innodb_log_files_in_group=2 
+         max_connections = 15360
+         innodb_buffer_pool_size = 10G
+         innodb_flush_method = O_DIRECT
+         innodb_file_per_table
+         innodb_flush_log_at_trx_commit = 0
+         innodb_log_file_size=1500M
+         innodb_log_files_in_group=2 
 
 Consider using [thread_handling=pool-of-threads](https://mariadb.com/kb/en/mariadb/documentation/optimization-and-tuning/buffers-caches-and-threads/thread-pool/threadpool-in-55/) option when mariadb needs to handle large number of not too active connection. Mariadb by default creates a thread for every connection, which consumes a significant amount a memory when it needs to handle thousands of connections.
 
 Avoid defining charset=utf8 without the use_unicode=0 in the mysql connection strings. <http://docs.sqlalchemy.org/en/rel_0_9/dialects/mysql.html#unicode>
 
-        rabbitmq:
-        if your erlang version support the hipe compile you can enable it in   /etc/rabbitmq/rabbitmq.config.
-`  `[`http://www.fpaste.org/125147/40791409`](http://www.fpaste.org/125147/40791409)
+        rabbitmq:
+        if your erlang version support the hipe compile you can enable it in   /etc/rabbitmq/rabbitmq.config.
+`  `[`http://www.fpaste.org/125147/40791409`](http://www.fpaste.org/125147/40791409)
 
 **Keystone**
 
-         Reduce default token duration on Keystone from 1 day  (86400) to 1 hour (3600)
+         Reduce default token duration on Keystone from 1 day  (86400) to 1 hour (3600)
 
-         Set expiration to 3600 in [token]  section in keystone.conf file on controller. 
+         Set expiration to 3600 in [token]  section in keystone.conf file on controller. 
 
-         Update revocation_cache_time from 1 to 300 with auth_token middleware. Till this is not changed in the code one need to update the each service specific file like glance-api.conf and add revocation_cache_time=300  in [keystone_authtoken] section.
+         Update revocation_cache_time from 1 to 300 with auth_token middleware. Till this is not changed in the code one need to update the each service specific file like glance-api.conf and add revocation_cache_time=300  in [keystone_authtoken] section.
 
-        Make sure you have crontab entry for '/usr/bin/keystone-manage token_flush' and it run on at least on one server at least once in every hour.
+        Make sure you have crontab entry for '/usr/bin/keystone-manage token_flush' and it run on at least on one server at least once in every hour.
 
 **Swift**
 
-         swift parameters missing in quickstack params.pp.  As such a foreman based packstack + quickstack deployment initial puppet runs fail to setup a cluster appropriately without adding to /usr/share/openstack-foreman-installer/puppet/modules/quickstack/manifests/params.pp:
+         swift parameters missing in quickstack params.pp.  As such a foreman based packstack + quickstack deployment initial puppet runs fail to setup a cluster appropriately without adding to /usr/share/openstack-foreman-installer/puppet/modules/quickstack/manifests/params.pp:
 
-         $swift_admin_password
+         $swift_admin_password
 
-         $swift_shared_secret
+         $swift_shared_secret

--- a/source/ha/foreman-ha-database.html.md
+++ b/source/ha/foreman-ha-database.html.md
@@ -12,7 +12,7 @@ wiki_last_updated: 2013-11-05
 
 To use HA/Mysql within an OpenStack deployment, you need to make sure to have your Mysql cluster up and running \*before\* spinning up the controller node(s), and make sure the controller Host Group has correct database IP (the virtual Mysql cluster IP) specified. You also need the HA channel enabled if you are on RHEL. Centos should not need this.
 
-      # yum-config-manager --enable rhel-ha-for-rhel-6-server-rpms
+      # yum-config-manager --enable rhel-ha-for-rhel-6-server-rpms
 
 At a high level, the required steps are:
 
@@ -26,12 +26,12 @@ Note the above does not set up any fencing configuration. In a production enviro
 
 The HA Mysql Host Group is responsible for starting Pacemaker and configuring the following resources within a resource group: the floating IP, shared storage for the Mysql server, and the mysql server process. E.g.:
 
-      # pcs status
+      # pcs status
       ...
-      Resource Group: mysqlgrp
-          ip-192.168.200.10  (ocf::heartbeat:IPaddr2):       Started 192.168.202.11
-          fs-varlibmysql     (ocf::heartbeat:Filesystem):    Started 192.168.202.11
-          mysql-ostk-mysql   (ocf::heartbeat:mysql): Started 192.168.202.11
+      Resource Group: mysqlgrp
+          ip-192.168.200.10  (ocf::heartbeat:IPaddr2):       Started 192.168.202.11
+          fs-varlibmysql     (ocf::heartbeat:Filesystem):    Started 192.168.202.11
+          mysql-ostk-mysql   (ocf::heartbeat:mysql): Started 192.168.202.11
 
 **Repository Requirements**
 

--- a/source/ha/rdo-mysql-multi-master-replication-active-active-ha.html.md
+++ b/source/ha/rdo-mysql-multi-master-replication-active-active-ha.html.md
@@ -38,21 +38,21 @@ In order to provide high availability and fault tolerance of the MySQL database,
 
 Typically, these physical hosts should easily be able to host the necessary VMs for all OpenStack control services provided they have enough RAM:
 
-       +---------------------+ +---------------------+
-        |   host system 1     | |   host system 2     |
-        | +-----------------+ | | +-----------------+ |
-        | | load balancer 1 | | | | load balancer 2 | |
-        | +-----------------+ | | +-----------------+ |
-        | +-----------------+ | | +-----------------+ |
-        | | mysql server 1  | | | | mysql server 2  | |
-        | +-----------------+ | | +-----------------+ |
-        | +-----------------+ | | +-----------------+ |
-        | | amqp server 1   | | | | amqp server 2   | |
-        | +-----------------+ | | +-----------------+ |
-        | +-----------------+ | | +-----------------+ |
-        | | controller 1    | | | | controller 2    | |
-        | +-----------------+ | | +-----------------+ |
-        +---------------------+ +---------------------+
+       +---------------------+ +---------------------+
+        |   host system 1     | |   host system 2     |
+        | +-----------------+ | | +-----------------+ |
+        | | load balancer 1 | | | | load balancer 2 | |
+        | +-----------------+ | | +-----------------+ |
+        | +-----------------+ | | +-----------------+ |
+        | | mysql server 1  | | | | mysql server 2  | |
+        | +-----------------+ | | +-----------------+ |
+        | +-----------------+ | | +-----------------+ |
+        | | amqp server 1   | | | | amqp server 2   | |
+        | +-----------------+ | | +-----------------+ |
+        | +-----------------+ | | +-----------------+ |
+        | | controller 1    | | | | controller 2    | |
+        | +-----------------+ | | +-----------------+ |
+        +---------------------+ +---------------------+
 
 The OpenStack MySQL database is not very large, but requires enough disk space for storing binary logs which are the key for database replication. For a medium sized cloud with 64 compute nodes and support for 4,000 2GB VMs, the following VM parameters are recommended:
 
@@ -82,8 +82,8 @@ To solve "The Arp Problem" in Direct Routing mode (see [1](http://www.austintek.
 
 1) Add the following lines to /etc/sysctl.conf then run 'sysctl -p':
 
-      net.ipv4.conf.all.arp_announce = 2
-      net.ipv4.conf.all.arp_ignore = 1
+      net.ipv4.conf.all.arp_announce = 2
+      net.ipv4.conf.all.arp_ignore = 1
 
 2) Create the file /etc/sysconfig/network-scripts/ifcfg-lo:3 with the following contents and start the interface by running 'ifup lo:3':
 
@@ -105,11 +105,11 @@ The following guide are based on the "Advanced MySQL Replication Techniques" ( [
 
 1) On each system, install the mysql client and server:
 
-      yum -y install mysql mysql-server 
+      yum -y install mysql mysql-server 
 
 2) Stop the mysql server on each system:
 
-      service mysqld stop 
+      service mysqld stop 
 
 3) Edit the /etc/my.cnf file on each system (NB: the my.cnf on each system will be slightly different).
 
@@ -117,182 +117,182 @@ On sql1, my.cnf should look like the following:
 
       ############################################################################
       [client]
-      port = 3306
-      socket = /var/lib/mysql/mysql.sock
-       
+      port = 3306
+      socket = /var/lib/mysql/mysql.sock
+       
       [mysqld_safe]
-      socket = /var/lib/mysql/mysql.sock
-      nice = 0
-      log = /var/log/mysqld.log
-      log-error = /var/log/mysqld.log
-      err-log = /var/log/mysqld.log
-      log-warnings = 2
-       
+      socket = /var/lib/mysql/mysql.sock
+      nice = 0
+      log = /var/log/mysqld.log
+      log-error = /var/log/mysqld.log
+      err-log = /var/log/mysqld.log
+      log-warnings = 2
+       
       [mysqld]
-      user = mysql
-      pid-file = /var/run/mysqld/mysqld.pid
-      socket = /var/lib/mysql/mysql.sock
-      port = 3306
-      basedir = /usr
-      datadir = /var/lib/mysql
-      tmpdir = /tmp
+      user = mysql
+      pid-file = /var/run/mysqld/mysqld.pid
+      socket = /var/lib/mysql/mysql.sock
+      port = 3306
+      basedir = /usr
+      datadir = /var/lib/mysql
+      tmpdir = /tmp
       skip-external-locking
-      bind-address = 0.0.0.0
-      key_buffer_size = 512M
-      table_cache = 512
-      myisam_sort_buffer_size = 100M
-      max_connections = 500
-      max_connect_errors = 1000
-      max_allowed_packet = 16M
-      thread_stack = 192K
-      thread_cache_size = 8
-      myisam-recover = BACKUP
-      query_cache_limit = 1M
-      query_cache_size = 16M
-      log_error = /var/log/mysqld.log
-      log-warning = 2
-      expire_logs_days = 14
-      max_binlog_size = 100M
-       
-      # If innodb is used
-      innodb_flush_log_at_trx_commit = 1
-       
-      # For replication. **Note** server-id and auto_increment_offset values!
-      server_id = 1
-      auto_increment_offset = 1
-      auto_increment_increment = 10
-      master-host = sql2.example.com
-      master-user = replication
-      master-password = secret_pw
-      sync_binlog = 1
-      log-bin = mysql-bin
+      bind-address = 0.0.0.0
+      key_buffer_size = 512M
+      table_cache = 512
+      myisam_sort_buffer_size = 100M
+      max_connections = 500
+      max_connect_errors = 1000
+      max_allowed_packet = 16M
+      thread_stack = 192K
+      thread_cache_size = 8
+      myisam-recover = BACKUP
+      query_cache_limit = 1M
+      query_cache_size = 16M
+      log_error = /var/log/mysqld.log
+      log-warning = 2
+      expire_logs_days = 14
+      max_binlog_size = 100M
+       
+      # If innodb is used
+      innodb_flush_log_at_trx_commit = 1
+       
+      # For replication. **Note** server-id and auto_increment_offset values!
+      server_id = 1
+      auto_increment_offset = 1
+      auto_increment_increment = 10
+      master-host = sql2.example.com
+      master-user = replication
+      master-password = secret_pw
+      sync_binlog = 1
+      log-bin = mysql-bin
       log-slave-updates
-      relay-log = sql1-relay-bin
-      slave_exec_mode = IDEMPOTENT
-       
-      # slave-skip-errors = 1062
-      # replicate-ignore-table = test.test
-      ############################################################################ 
+      relay-log = sql1-relay-bin
+      slave_exec_mode = IDEMPOTENT
+       
+      # slave-skip-errors = 1062
+      # replicate-ignore-table = test.test
+      ############################################################################ 
 
 On sql2, my.cnf should look like the following:
 
       ############################################################################
       [client]
-      port = 3306
-      socket = /var/lib/mysql/mysql.sock
-       
+      port = 3306
+      socket = /var/lib/mysql/mysql.sock
+       
       [mysqld_safe]
-      socket = /var/lib/mysql/mysql.sock
-      nice = 0
-      log = /var/log/mysqld.log
-      log-error = /var/log/mysqld.log
-      err-log = /var/log/mysqld.log
-      log-warnings = 2
-       
+      socket = /var/lib/mysql/mysql.sock
+      nice = 0
+      log = /var/log/mysqld.log
+      log-error = /var/log/mysqld.log
+      err-log = /var/log/mysqld.log
+      log-warnings = 2
+       
       [mysqld]
-      user = mysql
-      pid-file = /var/run/mysqld/mysqld.pid
-      socket = /var/lib/mysql/mysql.sock
-      port = 3306
-      basedir = /usr
-      datadir = /var/lib/mysql
-      tmpdir = /tmp
+      user = mysql
+      pid-file = /var/run/mysqld/mysqld.pid
+      socket = /var/lib/mysql/mysql.sock
+      port = 3306
+      basedir = /usr
+      datadir = /var/lib/mysql
+      tmpdir = /tmp
       skip-external-locking
-      bind-address = 0.0.0.0
-      key_buffer_size = 512M
-      table_cache = 512
-      myisam_sort_buffer_size = 100M
-      max_connections = 500
-      max_connect_errors = 1000
-      max_allowed_packet = 16M
-      thread_stack = 192K
-      thread_cache_size = 8
-      myisam-recover = BACKUP
-      query_cache_limit = 1M
-      query_cache_size = 16M
-      log_error = /var/log/mysqld.log
-      log-warning = 2
-      expire_logs_days = 14
-      max_binlog_size = 100M
-       
-      # If innodb is used
-      innodb_flush_log_at_trx_commit = 1
-       
-      # For replication. **Note** server-id and auto_increment_offset values!
-      server_id = 2
-      auto_increment_offset = 2
-      auto_increment_increment = 10
-      master-host = sql1.example.com
-      master-user = replication
-      master-password = secret_pw
-      sync_binlog = 1
-      log-bin = mysql-bin
+      bind-address = 0.0.0.0
+      key_buffer_size = 512M
+      table_cache = 512
+      myisam_sort_buffer_size = 100M
+      max_connections = 500
+      max_connect_errors = 1000
+      max_allowed_packet = 16M
+      thread_stack = 192K
+      thread_cache_size = 8
+      myisam-recover = BACKUP
+      query_cache_limit = 1M
+      query_cache_size = 16M
+      log_error = /var/log/mysqld.log
+      log-warning = 2
+      expire_logs_days = 14
+      max_binlog_size = 100M
+       
+      # If innodb is used
+      innodb_flush_log_at_trx_commit = 1
+       
+      # For replication. **Note** server-id and auto_increment_offset values!
+      server_id = 2
+      auto_increment_offset = 2
+      auto_increment_increment = 10
+      master-host = sql1.example.com
+      master-user = replication
+      master-password = secret_pw
+      sync_binlog = 1
+      log-bin = mysql-bin
       log-slave-updates
-      relay-log = sql2-relay-bin
-      slave_exec_mode = IDEMPOTENT
-       
-      # slave-skip-errors = 1062
-      # replicate-ignore-table = test.test
+      relay-log = sql2-relay-bin
+      slave_exec_mode = IDEMPOTENT
+       
+      # slave-skip-errors = 1062
+      # replicate-ignore-table = test.test
       ############################################################################
 
 4) On sql1 start the mysqld service and ignore any errors that may indicate that that the master-host options have been deprecated and will be removed in a future release. These errors are indeed correct, however, on the initialization of the multi-master replication database the options included in the my.cnf file will be used to generate an appropriate /var/lib/mysql/master.info file which then takes precedence over the options in my.cnf and the errors will go away in subsequent restarts.
 
 5) Start the mysql client on sql1 and issue the following commands:
 
-      mysql> grant replication slave, replication client on *.* to 'replication'@'sql2.example.com' identified by 'secret_pw';
-      mysql> grant replication slave, replication client on *.* to'replication'@'sql1.example.com' identified by 'secret_pw';
-      mysql> flush privileges;
+      mysql> grant replication slave, replication client on *.* to 'replication'@'sql2.example.com' identified by 'secret_pw';
+      mysql> grant replication slave, replication client on *.* to'replication'@'sql1.example.com' identified by 'secret_pw';
+      mysql> flush privileges;
 
 6) Remain logged into the mysql client and issue the following command to obtain the log file name and log position - record these values. (NB: do NOT terminate the mysql client session after you complete these commands - remain logged in to maintain the read lock):
 
-      mysql> slave stop;
-      mysql> flush tables with read lock;
-      mysql> show master status;
+      mysql> slave stop;
+      mysql> flush tables with read lock;
+      mysql> show master status;
 
 7) Start another login session into sql1 as root and rsync the mysql database directory from sql1 to sql2, excluding and deleting several files that are node specific:
 
-      [root sql1 ]# rsync -av -e ssh --delete --exclude=*relay-bin* --exclude=mysql-bin.* --exclude=*.info /var/lib/mysql/sql2.example.com:/var/lib/mysql 
+      [root sql1 ]# rsync -av -e ssh --delete --exclude=*relay-bin* --exclude=mysql-bin.* --exclude=*.info /var/lib/mysql/sql2.example.com:/var/lib/mysql 
 
 8) You may now safely log out of the mysql client on sql1.
 
 9) On sql2, start the mysqld:
 
-      service mysqld start 
+      service mysqld start 
 
 10) Start a mysql client session on sql2 and perform the following commands using the log file name and position recorded, above. NB: punctuation is very important:
 
-      mysql> slave stop; 
-      mysql> change master to master_log_file='<recorded log file name, above>', master_log_pos=<recorded log position, above>; # <- note lack of quotes mysql> start slave;
+      mysql> slave stop; 
+      mysql> change master to master_log_file='<recorded log file name, above>', master_log_pos=<recorded log position, above>; # <- note lack of quotes mysql> start slave;
 
 11) As with sql1, issue the following command to obtain the log file name and log position - record these values. (NB: do NOT terminate the mysql client session after you complete these commands - remain logged in to maintain the read lock):
 
-      mysql> flush tables with read lock;
-      mysql> show master status;
+      mysql> flush tables with read lock;
+      mysql> show master status;
 
 12) Log into sql1, start a mysql client session, and issue the following commands:
 
-      mysql> slave stop;
-      mysql> change master to master_log_file='<recorded log file name, above>', master_log_pos=<recorded log position, above>; # <- note lack of quotes mysql> start slave;
+      mysql> slave stop;
+      mysql> change master to master_log_file='<recorded log file name, above>', master_log_pos=<recorded log position, above>; # <- note lack of quotes mysql> start slave;
 
 13) It is now safe to exit any mysql client sessions that may be open to unlock the databases.
 
 14) Each database should now be in sync with each other, but to verify this, start a mysql client session on each system and issue the following command:
 
-      mysql> show slave status\G; 
+      mysql> show slave status\G; 
 
 15) Look at the values of Slave_IO_State, Slave_IO_Running, Slave_SQL_Running, and Seconds_Behind_Master. There should be no errors. If there are errors, then re-start the procedure at step 6.
 
 16) Additionally, create a test table and input some data on both systems. On sql1, run:
 
-      mysql> create table test.tester ( col1 int not null auto_increment, col2 int, primary key (col1) );
-      mysql> insert into tester (col2) values ('1'),('3'),('5');
-      mysql> select * from test.tester; 
+      mysql> create table test.tester ( col1 int not null auto_increment, col2 int, primary key (col1) );
+      mysql> insert into tester (col2) values ('1'),('3'),('5');
+      mysql> select * from test.tester; 
 
 On sql2, run:
 
-      mysql> select * from test.tester;
-      mysql> insert into tester (col2) values ('2'),('4'),('6');
-      mysql> select * from test.tester; 
+      mysql> select * from test.tester;
+      mysql> insert into tester (col2) values ('2'),('4'),('6');
+      mysql> select * from test.tester; 
 
 The select output should be the same on each system.
 
@@ -302,107 +302,107 @@ The select output should be the same on each system.
 
 1) On lb1 and lb2, install the piranha load balancing packages:
 
-       yum install piranha  
+       yum install piranha  
 
 2) Create the file /usr/local/bin/check_tcp_port.sh with the following contents, and make it executable:
 
       ############################################################################
       #!/bin/sh
-       
-      if [ -z $1 ] && [ -z $2 ]; then
-        echo "Usage: $0 addr port"
-        exit 1
+       
+      if [ -z $1 ] && [ -z $2 ]; then
+        echo "Usage: $0 addr port"
+        exit 1
       fi
-       
-      ` TEST=`/usr/bin/nc -zvv $1 $2 2>/dev/null | grep -c succeed` `
-       
-      if [ $TEST == 1 ]; then
-        echo "OK"
+       
+      ` TEST=`/usr/bin/nc -zvv $1 $2 2>/dev/null | grep -c succeed` `
+       
+      if [ $TEST == 1 ]; then
+        echo "OK"
       else
-        echo "FAIL"
+        echo "FAIL"
       fi
-       
-      exit 0
+       
+      exit 0
       ############################################################################
-        
+        
 
 3) Edit the /etc/sysconfig/ha/lvs.cf file on each load balancer and make it look like the following:
 
-      serial_no = 2013042401
-      service = lvs
-      primary = 10.0.0.1
-      service = lvs
-      rsh_command = ssh
-      backup_active = 1
-      backup = 10.0.0.2
-      heartbeat = 1
-      heartbeat_port = 539
-      keepalive = 6
-      deadtime = 18
-      debug_level = NONE
-      monitor_links = 1
-      syncdaemon = 1
-      hard_shutdown = 0
-      network = direct
-       
-      virtual openstack_mysql_3306 {
-        active = 1
-        address = 10.0.0.3 eth0:6
-        vip_nmask = 255.255.240.0
-        port = 3306
-        persistent = 60
-        pmask = 255.255.240.0
-        use_regex = 0
-        send_program = "/usr/local/bin/check_tcp_port.sh %h 3306"
-        send = "\n"
-        expect = "OK"
-        load_monitor = none
-        scheduler = wlc
-        protocol = tcp
-        timeout = 5
-        reentry = 10
-        quiesce_server = 1
-        server sql1.example.com {
-        address = 10.0.0.4
-        active = 1
-        weight = 1
-        }
-        server sql2.example.com {
-        address = 10.0.0.5
-        active = 1
-        weight = 1
-        }
+      serial_no = 2013042401
+      service = lvs
+      primary = 10.0.0.1
+      service = lvs
+      rsh_command = ssh
+      backup_active = 1
+      backup = 10.0.0.2
+      heartbeat = 1
+      heartbeat_port = 539
+      keepalive = 6
+      deadtime = 18
+      debug_level = NONE
+      monitor_links = 1
+      syncdaemon = 1
+      hard_shutdown = 0
+      network = direct
+       
+      virtual openstack_mysql_3306 {
+        active = 1
+        address = 10.0.0.3 eth0:6
+        vip_nmask = 255.255.240.0
+        port = 3306
+        persistent = 60
+        pmask = 255.255.240.0
+        use_regex = 0
+        send_program = "/usr/local/bin/check_tcp_port.sh %h 3306"
+        send = "\n"
+        expect = "OK"
+        load_monitor = none
+        scheduler = wlc
+        protocol = tcp
+        timeout = 5
+        reentry = 10
+        quiesce_server = 1
+        server sql1.example.com {
+        address = 10.0.0.4
+        active = 1
+        weight = 1
+        }
+        server sql2.example.com {
+        address = 10.0.0.5
+        active = 1
+        weight = 1
+        }
       }
-       
+       
 
 4) Shutdown the pulse service on lb2 and restart the pulse service on lb1.
 
-      service pulse restart
-        
+      service pulse restart
+        
 
 5) Verify that service is working by running the following command on lb1:
 
-      ipvsadm -Ln
-        
+      ipvsadm -Ln
+        
 
 The output should look like this:
 
-      IP Virtual Server version 1.2.1 (size=4096)
-      Prot LocalAddress:Port Scheduler Flags
-        -> RemoteAddress:Port Forward Weight ActiveConn InActConn
-      TCP 10.0.0.3:3306 wlc persistent 60 mask 255.255.240.0
-        -> 10.0.0.4:3306 Route 1 0 0
-        -> 10.0.0.5:3306 Route 1 0 0
-        
+      IP Virtual Server version 1.2.1 (size=4096)
+      Prot LocalAddress:Port Scheduler Flags
+        -> RemoteAddress:Port Forward Weight ActiveConn InActConn
+      TCP 10.0.0.3:3306 wlc persistent 60 mask 255.255.240.0
+        -> 10.0.0.4:3306 Route 1 0 0
+        -> 10.0.0.5:3306 Route 1 0 0
+        
 
 Also, tail /var/log/messages on the load balancers and look for the following:
 
-      Apr 3 15:02:13 lb1.example.com nanny[29298]: [ active ] making 10.0.0.5:3306 available
-        
+      Apr 3 15:02:13 lb1.example.com nanny[29298]: [ active ] making 10.0.0.5:3306 available
+        
 
 6) From a client on the network (NB: NOT the load balancer), connect to the service IP of the sql server:
 
-      [root client ]# mysql -u nova -h 10.0.0.3 -p
-        
+      [root client ]# mysql -u nova -h 10.0.0.3 -p
+        
 
 If this is successful, then congratulations, you have a fully functioning load-balanced multi-master mysql replication database system for your Red Hat OpenStack Cloud.

--- a/source/install/deploying-an-rdo-overcloud-with-instack.html.md
+++ b/source/install/deploying-an-rdo-overcloud-with-instack.html.md
@@ -18,13 +18,13 @@ However, instack-undercloud provides a test script, `instack-deploy-overcloud` t
 
 1. While logged into the undercloud node export the required variables into your shell in order to use the CLI tools for the undercloud and overcloud. If you copied the stackrc file into your home directory at the end of the undercloud installation, simply source that file. Alternatively, you can use the following command directly to set the needed environment variables.
 
-      command $(sudo cat /root/stackrc | xargs)
+      command $(sudo cat /root/stackrc | xargs)
 
 2. If doing a baremetal deployment, create a json file describing your baremetal nodes. See [this FAQ](https://rdoproject.org/Instack_FAQ#What_is_the_NODES_JSON_file_format.3F) for the documentation of the format of the file. For a virtual deployment, this file has already been created as instackenv.json, and you do not need to edit this file.
 
 3. A file named `deploy-overcloudrc` is used to define the needed environment variables to deploy an Overcloud. For a virtual environment setup, this file has already been created under `/home/stack`. For a baremetal setup, you will need to create the file yourself. There is a sample file included with instack-undercloud at `/usr/share/instack-undercloud/deploy-baremetal-overcloudrc`. Copy and edit the file as needed. For the NODES_JSON value, specify the path to the file that you created in the previous step. Example rc files containing values for the required variables can also be found in the [Instack FAQ](http://rdoproject.org/Instack_FAQ#Are_there_any_example_rc_files_for_Overcloud_deployment.3F). Note that the variables must be exported so that their values are picked up by `instack-deploy-overcloud`.
 
-      source deploy-overcloudrc
+      source deploy-overcloudrc
 
 4. Deploy the Overcloud
 
@@ -32,8 +32,8 @@ However, instack-undercloud provides a test script, `instack-deploy-overcloud` t
 
 5. To further interact with the API services running in the Overcloud using the OpenStack cli tools, you can run the following commands.
 
-      export TE_DATAFILE=instackenv.json
-      source /etc/tripleo/overcloudrc
+      export TE_DATAFILE=instackenv.json
+      source /etc/tripleo/overcloudrc
 
 Next steps: [ Testing an RDO Overcloud with Instack](Testing an RDO Overcloud with Instack). If you run into issues and want to redeploy your Overcloud the first step is to delete it using the instructions in the [FAQ](http://rdoproject.org/Instack_FAQ#How_do_I_delete_the_Overcloud.3F). You should then be able to re-execute instack-prepare-for-overcloud and deploy the Overcloud again.
 

--- a/source/install/deploying-multi-node-overcloud-using-tripleo-and-tuskar.html.md
+++ b/source/install/deploying-multi-node-overcloud-using-tripleo-and-tuskar.html.md
@@ -14,13 +14,13 @@ This task follows the steps to install RDO using the [Tuskar](//wiki.openstack.o
 
 The goal of the task is to:
 
-      - install the Undercloud
-      - download images needed for the Overcloud
-      - deploy an Overcloud with one Control node, Two Compute nodes and Two Block Storage nodes using Heat
-      - test that this Overcloud is functional by deploying a test instance within it
-      - tear down the Overcloud
-      - re-deploy the same Overcloud using Tuskar
-      - test that Overcloud
+      - install the Undercloud
+      - download images needed for the Overcloud
+      - deploy an Overcloud with one Control node, Two Compute nodes and Two Block Storage nodes using Heat
+      - test that this Overcloud is functional by deploying a test instance within it
+      - tear down the Overcloud
+      - re-deploy the same Overcloud using Tuskar
+      - test that Overcloud
 
 ## Undercloud Setup
 
@@ -38,21 +38,21 @@ Note that the images referenced in the link above may not always be available.
 
 Once the images are available in Glance, to deploy the overcloud using Heat, you can either:
 
-      - run 'deploy-overcloud' script 
-      - manually follow the steps in /usr/share/deploy-overcloud
+      - run 'deploy-overcloud' script 
+      - manually follow the steps in /usr/share/deploy-overcloud
 
 Note:
 
-      - you need to set values that are appropriate to your environment for the environment variables used deploying the Overcloud:  - $TRIPLEO_ROOT, $CPU, $MEM, $DISK, $ARCH, "$MACS", $PM_IPS",  "$PM_USERS",  "$PM_PASSWORDS", $NeutronPublicInterface, $OVERCLOUD_LIBVIRT_TYPE
-      - to deploy an Overcloud with Block Storage, you will need to include /usr/share/tripleo-heat-templates/block-storage.yaml when building the overcloud.yaml file
-      - to deploy an Overcloud with multiple Compute or Block Storage nodes, you need to modify the --scale (or COMPUTESCALE) argument.
+      - you need to set values that are appropriate to your environment for the environment variables used deploying the Overcloud:  - $TRIPLEO_ROOT, $CPU, $MEM, $DISK, $ARCH, "$MACS", $PM_IPS",  "$PM_USERS",  "$PM_PASSWORDS", $NeutronPublicInterface, $OVERCLOUD_LIBVIRT_TYPE
+      - to deploy an Overcloud with Block Storage, you will need to include /usr/share/tripleo-heat-templates/block-storage.yaml when building the overcloud.yaml file
+      - to deploy an Overcloud with multiple Compute or Block Storage nodes, you need to modify the --scale (or COMPUTESCALE) argument.
 
 ## Overcloud Test Steps
 
 Test the Overcloud by deploying a test instance by either:
 
-      - running the "test-overcloud" script
-      - or manually executing the steps in /usr/share/test-overcloud.
+      - running the "test-overcloud" script
+      - or manually executing the steps in /usr/share/test-overcloud.
 
 You should be able to ping the test instance but may not be able to ssh to it.
 
@@ -62,8 +62,8 @@ Note that some of the instructions linked below are changing. Please contact the
 
 To test the deploying the Overcloud with Tuskar,
 
-      - Tear down the current Overcloud (heat stack-delete overcloud) and remove the baremetal nodes (nova baremetal-node-delete)
-      - Configure Tuskar.  Edit /etc/tuskar/tuskar.conf so the following settings are enabled:
+      - Tear down the current Overcloud (heat stack-delete overcloud) and remove the baremetal nodes (nova baremetal-node-delete)
+      - Configure Tuskar.  Edit /etc/tuskar/tuskar.conf so the following settings are enabled:
 
     connection=sqlite:////home/stack/tuskar.sqlite   
     tht_local_dir=/usr/share/tripleo-heat-templates/
@@ -73,13 +73,13 @@ To test the deploying the Overcloud with Tuskar,
     auth_url=http://localhost:5000/v2.0   
     insecure=true 
 
-      - Initialise the Tuskar database and restart the service
+      - Initialise the Tuskar database and restart the service
 
     sudo tuskar-dbsync --config-file /etc/tuskar/tuskar.conf
     sudo service openstack-tuskar-api restart
 
-      - Follow the steps linked here to deploy the Overcloud using Tuskar: `[`https://github.com/agroup/instack-undercloud/blob/master/scripts/instack-deploy-overcloud-tuskarcli`](https://github.com/agroup/instack-undercloud/blob/master/scripts/instack-deploy-overcloud-tuskarcli)` 
-      - Be aware of syntax changes for tuskar overcloud-create: "--attributes" is now "--attribute" and "--roles" is now "--role-count"
-      - To deploy multiple Compute or Block Storage nodes, change the number of the roles in "tuskar overcloud-create"
+      - Follow the steps linked here to deploy the Overcloud using Tuskar: `[`https://github.com/agroup/instack-undercloud/blob/master/scripts/instack-deploy-overcloud-tuskarcli`](https://github.com/agroup/instack-undercloud/blob/master/scripts/instack-deploy-overcloud-tuskarcli)` 
+      - Be aware of syntax changes for tuskar overcloud-create: "--attributes" is now "--attribute" and "--roles" is now "--role-count"
+      - To deploy multiple Compute or Block Storage nodes, change the number of the roles in "tuskar overcloud-create"
 
 You can test the Overcloud using the "test-overcloud" script mentioned in the section above.

--- a/source/install/deploying-rdo-on-a-virtual-machine-environment-using-instack.html.md
+++ b/source/install/deploying-rdo-on-a-virtual-machine-environment-using-instack.html.md
@@ -37,10 +37,10 @@ RHEL 7 support is experimental and may not work with the currently released pack
 
 2. The user performing all of the installation steps on the virt host needs to have sudo enabled. You can use an existing user or use the following commands to create a new user called **stack** with password-less sudo enabled. **Do not run the rest of the steps in this guide as root.**
 
-       sudo useradd stack
-       sudo passwd stack  # specify a password
-       echo "stack ALL=(root) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/stack
-       sudo chmod 0440 /etc/sudoers.d/stack
+       sudo useradd stack
+       sudo passwd stack  # specify a password
+       echo "stack ALL=(root) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/stack
+       sudo chmod 0440 /etc/sudoers.d/stack
 
 If you have previously used the host machine to run TripleO's devtest setup, then that could potentially conflict with the scripts installed from RDO packages. It is recommended to clean up from any previous devtest runs by deleting ~/.cache/tripleo and making sure there is no $TRIPLEO_ROOT defined in your environment.
 
@@ -52,25 +52,25 @@ These steps will setup your virtual host for a virtual environment for testing t
 
 2. Add export of LIBVIRT_DEFAULT_URI to your bashrc file.
 
-        echo 'export LIBVIRT_DEFAULT_URI="qemu:///system"' >> ~/.bashrc
+        echo 'export LIBVIRT_DEFAULT_URI="qemu:///system"' >> ~/.bashrc
 
 3. Enable the RDO juno repository
 
-`  sudo yum install -y `[`http://rdo.fedorapeople.org/openstack-juno/rdo-release-juno.rpm`](http://rdo.fedorapeople.org/openstack-juno/rdo-release-juno.rpm)
+`  sudo yum install -y `[`http://rdo.fedorapeople.org/openstack-juno/rdo-release-juno.rpm`](http://rdo.fedorapeople.org/openstack-juno/rdo-release-juno.rpm)
 
 If on RHEL 7, enable the EPEL repository too
 
-` sudo yum install -y `[`http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm`](http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm)
+` sudo yum install -y `[`http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm`](http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm)
 
 4 . Install the instack-undercloud package.
 
-       sudo yum install -y instack-undercloud
+       sudo yum install -y instack-undercloud
 
 5. Configure your environment for your selected distribution, replacing the values in [] with the appropriate ones for your environment.
 
 Fedora 20
 
-       export NODE_DIST="fedora"
+       export NODE_DIST="fedora"
 
 RHEL 7, registered with the customer portal
 
@@ -88,28 +88,28 @@ RHEL 7, registered with the customer portal
 
 6. Run scripts to install required dependencies
 
-       source /usr/libexec/openstack-tripleo/devtest_variables.sh
-       tripleo install-dependencies
-       tripleo set-usergroup-membership
-       # The previous command has added the user to the libvirtd group, so we need to login to the new group
-       newgrp libvirtd
-       newgrp
+       source /usr/libexec/openstack-tripleo/devtest_variables.sh
+       tripleo install-dependencies
+       tripleo set-usergroup-membership
+       # The previous command has added the user to the libvirtd group, so we need to login to the new group
+       newgrp libvirtd
+       newgrp
 
 ### Virtual Machine Creation
 
 1. Verify again that your user has been added to the libvirtd group. The command shown below should show the libvirtd group listed in the output.
 
-      id | grep libvirtd
+      id | grep libvirtd
 
 2. Run the script to setup your virtual environment.
 
-       instack-virt-setup
+       instack-virt-setup
 
 When the script has completed successfully it will output the IP address of the instack vm.
 
 Running `virsh list --all` will show you now have one virtual machine called instack" and four called "baremetal[0-4]", all shut off. The "instack" vm runs a minimal install of Fedora 20 x86_64 and will be used to install the undercloud on. You can login to the instack vm by running:
 
-` ssh -i .ssh/id_rsa_virt_power root@`<instack-vm-ip>
+` ssh -i .ssh/id_rsa_virt_power root@`<instack-vm-ip>
 
 The vm contains a user "stack" that uses the password "stack" and is granted password-less sudo privileges. Once logged in as root to the instack vm, you can su to the stack user. The other vm's don't have an operating system yet installed but will eventually become part of the "overcloud".
 

--- a/source/install/deploying-rhelosp-using-tripleo.html.md
+++ b/source/install/deploying-rhelosp-using-tripleo.html.md
@@ -32,13 +32,13 @@ Download the RHEL 7 guest image from the Red Hat Customer Portal [<https://acces
 
 The following environment variables must be defined in the shell environment
 
-      export RHOS=1
-      export NODE_DIST="rhel7"
-      export DIB_YUM_REPO_CONF=/path/to/yum/repo-file.repo
-      # The name of the guest image downloaded from the Red Hat Customer Portal
-      export DIB_LOCAL_IMAGE="/path/to/rhel-guest-image-7.0-20140930.0.x86_64.qcow2"
-      export REG_METHOD=disable
-      export REG_HALT_UNREGISTER=1
+      export RHOS=1
+      export NODE_DIST="rhel7"
+      export DIB_YUM_REPO_CONF=/path/to/yum/repo-file.repo
+      # The name of the guest image downloaded from the Red Hat Customer Portal
+      export DIB_LOCAL_IMAGE="/path/to/rhel-guest-image-7.0-20140930.0.x86_64.qcow2"
+      export REG_METHOD=disable
+      export REG_HALT_UNREGISTER=1
 
 Then proceed with running `instack-virt-setup`
 
@@ -50,13 +50,13 @@ Download the RHEL 7 guest image from the Red Hat Customer Portal [<https://acces
 
 The following environment variables must be defined in the shell environment
 
-      export RHOS=1
-      export NODE_DIST="rhel7"
-      export DIB_YUM_REPO_CONF=/path/to/yum/repo-file.repo
-      # The name of the guest image downloaded from the Red Hat Customer Portal
-      export DIB_LOCAL_IMAGE="/path/to/rhel-guest-image-7.0-20140930.0.x86_64.qcow2"
-      export REG_METHOD=disable
-      export REG_HALT_UNREGISTER=1
+      export RHOS=1
+      export NODE_DIST="rhel7"
+      export DIB_YUM_REPO_CONF=/path/to/yum/repo-file.repo
+      # The name of the guest image downloaded from the Red Hat Customer Portal
+      export DIB_LOCAL_IMAGE="/path/to/rhel-guest-image-7.0-20140930.0.x86_64.qcow2"
+      export REG_METHOD=disable
+      export REG_HALT_UNREGISTER=1
 
 The following command will then create all the Overcloud images, and they will be saved in the current directory.
 
@@ -66,7 +66,7 @@ The following command will then create all the Overcloud images, and they will b
 
 Prior to running `instack-test-overcloud` in a virtual machine environment, an updated version of the Fedora cloud image must be downloaded as the RHEL guest image does not boot under qemu only virtualization. Use the following command on the Undercloud to download the updated Fedora cloud image.
 
-`curl -o /home/stack/fedora-user.qcow2 `[`http://dl.fedoraproject.org/pub/alt/openstack/20/x86_64/Fedora-x86_64-20-20140618-sda.qcow2`](http://dl.fedoraproject.org/pub/alt/openstack/20/x86_64/Fedora-x86_64-20-20140618-sda.qcow2)
+`curl -o /home/stack/fedora-user.qcow2 `[`http://dl.fedoraproject.org/pub/alt/openstack/20/x86_64/Fedora-x86_64-20-20140618-sda.qcow2`](http://dl.fedoraproject.org/pub/alt/openstack/20/x86_64/Fedora-x86_64-20-20140618-sda.qcow2)
 
 ## Using a Satellite Server for RHELOSP and RHEL Content
 
@@ -74,16 +74,16 @@ While not as extensively tested, it is also possible to use a Satellite server f
 
 When using a Satellite Server, the following set of environment variables should be defined in your environment prior to running `instack-virt-setup`, `instack-install-undercloud`, or `instack-build-images`.
 
-      export RHOS=1
-      export NODE_DIST="rhel7"
-      # The name of the guest image downloaded from the Red Hat Customer Portal
-      export DIB_LOCAL_IMAGE="/path/to/rhel-guest-image-7.0-20140930.0.x86_64.qcow2"
-      export REG_METHOD=satellite
-`export REG_SAT_URL="`[`http://`](http://)<satellite-server"
+      export RHOS=1
+      export NODE_DIST="rhel7"
+      # The name of the guest image downloaded from the Red Hat Customer Portal
+      export DIB_LOCAL_IMAGE="/path/to/rhel-guest-image-7.0-20140930.0.x86_64.qcow2"
+      export REG_METHOD=satellite
+`export REG_SAT_URL="`[`http://`](http://)<satellite-server"
  # Find this with `subscription-manager list --available`
  export REG_POOL_ID="<pool-id>`"`
-      export REG_USER="`&lt;username&gt;`"
-      export REG_PASSWORD="`<password>`"
-      export REG_REPOS="`<list of space separated repositories>`"
+      export REG_USER="`&lt;username&gt;`"
+      export REG_PASSWORD="`<password>`"
+      export REG_REPOS="`<list of space separated repositories>`"
 
 `REG_REPOS` should be a space seperated list of repository id's for RHELOSP 6, RHEL 7 Base, RHEL 7 Optional, RHEL 7 Extras, and RHEL 7 HA.

--- a/source/install/instack-faq.html.md
+++ b/source/install/instack-faq.html.md
@@ -129,11 +129,11 @@ There are delete scripts included with the instack-undercloud package If you wan
 
 1. While logged into the undercloud node export the required variables into your shell in order to use the CLI tools for the undercloud and overcloud. If you copied the stackrc file into your home directory at the end of the undercloud installation, simply source that file. Alternatively, you can use the following command directly to set the needed environment variables.
 
-      command $(sudo cat /root/stackrc | xargs)
+      command $(sudo cat /root/stackrc | xargs)
 
 2. Run one of the following examples that matches how you deployed the overcloud.
 
-       instack-delete-overcloud
+       instack-delete-overcloud
 
 ## How do I load new Overcloud images?
 
@@ -141,18 +141,18 @@ If new images are made available for download, or you build new images, you will
 
 1. While logged into the undercloud node export the required variables into your shell in order to use the CLI tools for the undercloud and overcloud. If you copied the stackrc file into your home directory at the end of the undercloud installation, simply source that file. Alternatively, you can use the following command directly to set the needed environment variables.
 
-      command $(sudo cat /root/stackrc | xargs)
+      command $(sudo cat /root/stackrc | xargs)
 
 2. Use the following command to load new images. Pass the command whatever new image file you want loaded into glance.
 
-      tripleo load-image -d overcloud-control.qcow2
+      tripleo load-image -d overcloud-control.qcow2
 
 ## How do I view the Undercloud Dashboard when using a remote virt host?
 
 If your virt host is a remote system, and not the same system that you're running your web browser from, you can create an ssh tunnel from the virt host to the instack virtual machine for connectivity. On the virt host enter the following:
 
-       sudo iptables -I INPUT -p tcp --dport 8080 -j ACCEPT
-      `  ssh -g -N -L 8080:192.168.122.55:80 `hostname` `
+       sudo iptables -I INPUT -p tcp --dport 8080 -j ACCEPT
+      `  ssh -g -N -L 8080:192.168.122.55:80 `hostname` `
 
 where 192.168.122.55 is the IP address of the instack virtual machine. Update appropriately for your environment. With the ssh tunnel created you can launch a browser on a system with connectivity to the virt host and go to <http://><virt-host>:8080/dashboard and the dashboard should appear. If you need to connect remotely through the virt host, you can chain ssh tunnels as needed.
 

--- a/source/install/tripleo-cli.html.md
+++ b/source/install/tripleo-cli.html.md
@@ -16,9 +16,9 @@ Instack is used to create the undercloud. This can be either done on a fully vir
 
 To setup your shell environment with the correct configuration and authentication details for your deployment you will need to run the following commands.
 
-      source ~/deploy-overcloudrc
-      source ~/tripleo-undercloud-passwords
-      source ~/stackrc
+      source ~/deploy-overcloudrc
+      source ~/tripleo-undercloud-passwords
+      source ~/stackrc
 
 These will need to be entered each time you start a new shell session for the following commands in this page to work.
 
@@ -28,66 +28,66 @@ You will need to register your bare-metal hardware as nodes in Ironic. This can 
 
 Option 1: Use register-nodes from os-cloud-config to load the nodes JSON. The JSON file should match the following structure.
 
-       [
-         {
-           "arch": "x86_64",
-           "pm_user": "stack",
-           "pm_addr": "192.168.122.1",
-           "pm_password": "-----BEGIN RSA PRIVATE KEY-----$SNIP-----END RSA PRIVATE KEY-----",
-           "pm_type": "pxe_ssh",
-           "mac": [
-             "00:0b:d0:69:7e:59"
-           ],
-           "cpu": "1",
-           "memory": "4096",
-           "disk": "40"
-         },
-         {
-           "arch": "x86_64",
-           "pm_user": "stack",
-           "pm_addr": "192.168.122.2",
-           "pm_password": "-----BEGIN RSA PRIVATE KEY-----$SNIP-----END RSA PRIVATE KEY-----",
-           "pm_type": "pxe_ssh",
-           "mac": [
-             "00:0b:d0:69:7e:58"
-           ],
-           "cpu": "1",
-           "memory": "4096",
-           "disk": "40"
-         }
-       ]
+       [
+         {
+           "arch": "x86_64",
+           "pm_user": "stack",
+           "pm_addr": "192.168.122.1",
+           "pm_password": "-----BEGIN RSA PRIVATE KEY-----$SNIP-----END RSA PRIVATE KEY-----",
+           "pm_type": "pxe_ssh",
+           "mac": [
+             "00:0b:d0:69:7e:59"
+           ],
+           "cpu": "1",
+           "memory": "4096",
+           "disk": "40"
+         },
+         {
+           "arch": "x86_64",
+           "pm_user": "stack",
+           "pm_addr": "192.168.122.2",
+           "pm_password": "-----BEGIN RSA PRIVATE KEY-----$SNIP-----END RSA PRIVATE KEY-----",
+           "pm_type": "pxe_ssh",
+           "mac": [
+             "00:0b:d0:69:7e:58"
+           ],
+           "cpu": "1",
+           "memory": "4096",
+           "disk": "40"
+         }
+       ]
 
 This can then be loaded like this:
 
-      register-nodes --service-host undercloud --nodes $JSON_FILE
+      register-nodes --service-host undercloud --nodes $JSON_FILE
 
 Option 2: Use the ironic client and `ironic node-create` and `ironic port-create` to add them one at a time.
 
-      $ ironic node-create -d pxe_ssh \
-          -p cpus=1 -p memory_mb=4096 -p local_gb=40 -p cpu_arch=x86_64 \
-          -i ssh_username=stack -i ssh_virt_type=virsh -i ssh_address="192.168.122.1" -i ssh_key_contents="key"
+      $ ironic node-create -d pxe_ssh \
+          -p cpus=1 -p memory_mb=4096 -p local_gb=40 -p cpu_arch=x86_64 \
+          -i ssh_username=stack -i ssh_virt_type=virsh -i ssh_address="192.168.122.1" -i ssh_key_contents="key"
       +--------------+-------------------------------------------------------------------------+
-      | Property     | Value                                                                   |
+      | Property     | Value                                                                   |
       +--------------+-------------------------------------------------------------------------+
-      | uuid         | 8d9e4de3-8a57-417e-8c96-789555be372c                                    |
-      | driver_info  | {u'ssh_username': u'stack', u'ssh_virt_type': u'virsh', u'ssh_address': |
-      |              | u'192.168.122.1', u'ssh_key_contents': u'key'}                          |
-      | extra        | {}                                                                      |
-      | driver       | pxe_ssh                                                                 |
-      | chassis_uuid | None                                                                    |
-      | properties   | {u'memory_mb': u'4096', u'cpu_arch': u'x86_64', u'local_gb': u'40',     |
-      |              | u'cpus': u'1'}                                                          |
+      | uuid         | 8d9e4de3-8a57-417e-8c96-789555be372c                                    |
+      | driver_info  | {u'ssh_username': u'stack', u'ssh_virt_type': u'virsh', u'ssh_address': |
+      |              | u'192.168.122.1', u'ssh_key_contents': u'key'}                          |
+      | extra        | {}                                                                      |
+      | driver       | pxe_ssh                                                                 |
+      | chassis_uuid | None                                                                    |
+      | properties   | {u'memory_mb': u'4096', u'cpu_arch': u'x86_64', u'local_gb': u'40',     |
+      |              | u'cpus': u'1'}                                                          |
       +--------------+-------------------------------------------------------------------------+
-      $ ironic port-create -a "00:7e:11:29:45:4e" -n 8d9e4de3-8a57-417e-8c96-789555be372c
+      $ ironic port-create -a "00:7e:11:29:45:4e" -n 8d9e4de3-8a57-417e-8c96-789555be372c
       +-----------+--------------------------------------+
-      | Property  | Value                                |
+      | Property  | Value                                |
       +-----------+--------------------------------------+
-      | node_uuid | 8d9e4de3-8a57-417e-8c96-789555be372c |
-      | extra     | {}                                   |
-      | uuid      | 1b93f57b-2add-45ca-bac4-c8e104ef4d63 |
-      | address   | 00:7e:11:29:45:4e                    |
+      | node_uuid | 8d9e4de3-8a57-417e-8c96-789555be372c |
+      | extra     | {}                                   |
+      | uuid      | 1b93f57b-2add-45ca-bac4-c8e104ef4d63 |
+      | address   | 00:7e:11:29:45:4e                    |
       +-----------+--------------------------------------+
-      $ ironic node-set-power-state 8d9e4de3-8a57-417e-8c96-789555be372c off
+      $ ironic node-set-power-state 8d9e4de3-8a57-417e-8c96-789555be372c off
 
 ## OpenStack Setup
 
@@ -95,16 +95,16 @@ Flavors are used to assign roles in the deployment plan to specific nodes in you
 
 The following example creates a different flavor for the four standard roles, however, sharing flavors between roles is possible.
 
-      nova flavor-create control auto 4096 40 2
-      nova flavor-create compute auto 1024 40 1
-      nova flavor-create cinder-storage auto 1024 40 1
-      nova flavor-create swift-storage auto 1024 40 1
-      deploy_kernel_id=$(glance image-show bm-deploy-kernel | awk ' / id / {print $4}')
-      deploy_ramdisk_id=$(glance image-show bm-deploy-ramdisk | awk ' / id / {print $4}')
-      nova flavor-key control set "cpu_arch"="x86_64" "baremetal:deploy_kernel_id"="$deploy_kernel_id" "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id"
-      nova flavor-key compute set "cpu_arch"="x86_64" "baremetal:deploy_kernel_id"="$deploy_kernel_id" "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id"
-      nova flavor-key cinder-storage set "cpu_arch"="x86_64" "baremetal:deploy_kernel_id"="$deploy_kernel_id" "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id"
-      nova flavor-key swift-storage set "cpu_arch"="x86_64" "baremetal:deploy_kernel_id"="$deploy_kernel_id" "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id"
+      nova flavor-create control auto 4096 40 2
+      nova flavor-create compute auto 1024 40 1
+      nova flavor-create cinder-storage auto 1024 40 1
+      nova flavor-create swift-storage auto 1024 40 1
+      deploy_kernel_id=$(glance image-show bm-deploy-kernel | awk ' / id / {print $4}')
+      deploy_ramdisk_id=$(glance image-show bm-deploy-ramdisk | awk ' / id / {print $4}')
+      nova flavor-key control set "cpu_arch"="x86_64" "baremetal:deploy_kernel_id"="$deploy_kernel_id" "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id"
+      nova flavor-key compute set "cpu_arch"="x86_64" "baremetal:deploy_kernel_id"="$deploy_kernel_id" "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id"
+      nova flavor-key cinder-storage set "cpu_arch"="x86_64" "baremetal:deploy_kernel_id"="$deploy_kernel_id" "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id"
+      nova flavor-key swift-storage set "cpu_arch"="x86_64" "baremetal:deploy_kernel_id"="$deploy_kernel_id" "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id"
 
 In the Deployment section which follows below, we will look at how to specify the flavors (with the command `tuskar plan-patch`) we want to use when we deploy.
 
@@ -116,30 +116,30 @@ To deploy the Overcloud a deployment plan needs to be created with the Tuskar pl
 
 When Tuskar is installed it will create a default Plan called `overcloud` which should be used. At the moment only one deployment is supported within Tuskar. You can see this Deployment Plan with the command `tuskar plan-list`.
 
-      $ tuskar plan-list
+      $ tuskar plan-list
       +--------------------------------------+-----------+-------------+----------------------------------------------------+
-      | uuid                                 | name      | description | roles                                              |
+      | uuid                                 | name      | description | roles                                              |
       +--------------------------------------+-----------+-------------+----------------------------------------------------+
-      | f57884c9-ed35-421e-b331-b2dc38b656af | overcloud | None        | controller, swift-storage, compute, cinder-storage |
+      | f57884c9-ed35-421e-b331-b2dc38b656af | overcloud | None        | controller, swift-storage, compute, cinder-storage |
       +--------------------------------------+-----------+-------------+----------------------------------------------------+
 
 The plan by default has the roles controller swift-storage, compute and cinder-storage. These are the four roles that Tuskar comes with as standard. The roles can all be seen with the command `tuskar roles-list`
 
-      $ tuskar role-list
+      $ tuskar role-list
       +--------------------------------------+----------------+---------+------------------------------------------------------------------------------+
-      | uuid                                 | name           | version | description                                                                  |
+      | uuid                                 | name           | version | description                                                                  |
       +--------------------------------------+----------------+---------+------------------------------------------------------------------------------+
-      | 023031ea-2dd9-43b4-9dd2-e9ebfb71710c | cinder-storage | 1       | Common Block Storage Configuration                                           |
-      | 71f5b6c8-d423-482c-bc4a-e7103e67d7dc | swift-storage  | 1       | Common Swift Storage Configuration                                           |
-      | 950b6757-7804-41aa-93a7-f50b099b0159 | controller     | 1       | OpenStack control plane node. Can be wrapped in a ResourceGroup for scaling. |
-      |                                      |                |         |                                                                              |
-      | b2a5f50e-a088-45d1-b4ac-2751a607628a | compute        | 1       | OpenStack hypervisor node. Can be wrapped in a ResourceGroup for scaling.    |
-      |                                      |                |         |                                                                              |
+      | 023031ea-2dd9-43b4-9dd2-e9ebfb71710c | cinder-storage | 1       | Common Block Storage Configuration                                           |
+      | 71f5b6c8-d423-482c-bc4a-e7103e67d7dc | swift-storage  | 1       | Common Swift Storage Configuration                                           |
+      | 950b6757-7804-41aa-93a7-f50b099b0159 | controller     | 1       | OpenStack control plane node. Can be wrapped in a ResourceGroup for scaling. |
+      |                                      |                |         |                                                                              |
+      | b2a5f50e-a088-45d1-b4ac-2751a607628a | compute        | 1       | OpenStack hypervisor node. Can be wrapped in a ResourceGroup for scaling.    |
+      |                                      |                |         |                                                                              |
       +--------------------------------------+----------------+---------+------------------------------------------------------------------------------+
 
 To set the require attributes in the Deployment Plan use the Tuskar command plan-patch.
 
-      tuskar plan-patch -A $ATTRIBUTE1=$VALUE1 -A $ATTRIBUTE2=$VALUE2 ... $PLAN_ID
+      tuskar plan-patch -A $ATTRIBUTE1=$VALUE1 -A $ATTRIBUTE2=$VALUE2 ... $PLAN_ID
 
 A full list of the attributes and their current values can be seen in the output of `tuskar plan-show overcloud`
 
@@ -147,17 +147,17 @@ A full list of the attributes and their current values can be seen in the output
 
 At this stage we can use the attributes to control the flavor used by each role.
 
-      tuskar plan-patch -A compute-1::Flavor=compute $PLAN_ID
-      tuskar plan-patch -A swift-storage-1::Flavor=swift-storage $PLAN_ID
-      tuskar plan-patch -A controller-1::Flavor=controller $PLAN_ID
-      tuskar plan-patch -A cinder-storage-1::Flavor=cinder-storage $PLAN_ID
+      tuskar plan-patch -A compute-1::Flavor=compute $PLAN_ID
+      tuskar plan-patch -A swift-storage-1::Flavor=swift-storage $PLAN_ID
+      tuskar plan-patch -A controller-1::Flavor=controller $PLAN_ID
+      tuskar plan-patch -A cinder-storage-1::Flavor=cinder-storage $PLAN_ID
 
 Once the attributes have been set in the Deployment Plan it can be reviewed with plan-show as described above. After this has been checked the Heat templates can be retried from Tuskar and a stack create can be executed.
 
-      tuskar plan-templates -O tuskar_templates $PLAN_ID
-      heat stack-create -f tuskar_templates/plan.yaml \
-         -e tuskar_templates/environment.yaml \
-         overcloud
+      tuskar plan-templates -O tuskar_templates $PLAN_ID
+      heat stack-create -f tuskar_templates/plan.yaml \
+         -e tuskar_templates/environment.yaml \
+         overcloud
 
 If there are any problems with the Heat stack update, the Heat engine log under `/var/log/heat/engine.log` is a good place to start debugging.
 
@@ -165,45 +165,45 @@ If there are any problems with the Heat stack update, the Heat engine log under 
 
 The ironic client can be used to view your infrastructure. To get an overview, use the following command which will list all registered nodes and the state of that node.
 
-      $ ironic node-list
+      $ ironic node-list
       +--------------------------------------+---------------+-------------+--------------------+-------------+
-      | UUID                                 | Instance UUID | Power State | Provisioning State | Maintenance |
+      | UUID                                 | Instance UUID | Power State | Provisioning State | Maintenance |
       +--------------------------------------+---------------+-------------+--------------------+-------------+
-      | b75f16bf-b76d-4a01-a2cf-a5a395bec765 | None          | power off   | None               | False       |
-      | 357e84e8-bf32-4a6a-8540-79a126070b8f | None          | power off   | None               | False       |
-      | 263ff2f1-2f75-4a9a-95aa-b475b9160ec4 | None          | power off   | None               | False       |
-      | 8412a224-634f-40a1-8aff-4b24148cb735 | None          | power off   | None               | False       |
+      | b75f16bf-b76d-4a01-a2cf-a5a395bec765 | None          | power off   | None               | False       |
+      | 357e84e8-bf32-4a6a-8540-79a126070b8f | None          | power off   | None               | False       |
+      | 263ff2f1-2f75-4a9a-95aa-b475b9160ec4 | None          | power off   | None               | False       |
+      | 8412a224-634f-40a1-8aff-4b24148cb735 | None          | power off   | None               | False       |
       +--------------------------------------+---------------+-------------+--------------------+-------------+
 
 To view the detail for each individual node, use the following command with the ID in the output from above.
 
-      $ ironic node-show 263ff2f1-2f75-4a9a-95aa-b475b9160ec4
+      $ ironic node-show 263ff2f1-2f75-4a9a-95aa-b475b9160ec4
       +------------------------+--------------------------------------------------------------------------+
-      | Property               | Value                                                                    |
+      | Property               | Value                                                                    |
       +------------------------+--------------------------------------------------------------------------+
-      | instance_uuid          | None                                                                     |
-      | target_power_state     | None                                                                     |
-      | properties             | {u'memory_mb': u'4096', u'cpu_arch': u'x86_64', u'local_gb': u'40',      |
-      |                        | u'cpus': u'1'}                                                           |
-      | maintenance            | False                                                                    |
-      | driver_info            | {u'ssh_username': u'stack', u'ssh_virt_type': u'virsh', u'ssh_address':  |
-      |                        | u'192.168.122.1', u'ssh_key_contents': u'-----BEGIN RSA PRIVATE KEY----- |
-      |                        | `<SNIP>`                                                                   |
-      |                        | -----END RSA                                                             |
-      |                        | PRIVATE KEY-----'}                                                       |
-      | extra                  | {}                                                                       |
-      | last_error             | None                                                                     |
-      | created_at             | 2015-02-05T13:50:36+00:00                                                |
-      | target_provision_state | None                                                                     |
-      | driver                 | pxe_ssh                                                                  |
-      | updated_at             | 2015-02-09T15:04:08+00:00                                                |
-      | instance_info          | {}                                                                       |
-      | chassis_uuid           | None                                                                     |
-      | provision_state        | None                                                                     |
-      | reservation            | None                                                                     |
-      | power_state            | power off                                                                |
-      | console_enabled        | False                                                                    |
-      | uuid                   | 263ff2f1-2f75-4a9a-95aa-b475b9160ec4                                     |
+      | instance_uuid          | None                                                                     |
+      | target_power_state     | None                                                                     |
+      | properties             | {u'memory_mb': u'4096', u'cpu_arch': u'x86_64', u'local_gb': u'40',      |
+      |                        | u'cpus': u'1'}                                                           |
+      | maintenance            | False                                                                    |
+      | driver_info            | {u'ssh_username': u'stack', u'ssh_virt_type': u'virsh', u'ssh_address':  |
+      |                        | u'192.168.122.1', u'ssh_key_contents': u'-----BEGIN RSA PRIVATE KEY----- |
+      |                        | `<SNIP>`                                                                   |
+      |                        | -----END RSA                                                             |
+      |                        | PRIVATE KEY-----'}                                                       |
+      | extra                  | {}                                                                       |
+      | last_error             | None                                                                     |
+      | created_at             | 2015-02-05T13:50:36+00:00                                                |
+      | target_provision_state | None                                                                     |
+      | driver                 | pxe_ssh                                                                  |
+      | updated_at             | 2015-02-09T15:04:08+00:00                                                |
+      | instance_info          | {}                                                                       |
+      | chassis_uuid           | None                                                                     |
+      | provision_state        | None                                                                     |
+      | reservation            | None                                                                     |
+      | power_state            | power off                                                                |
+      | console_enabled        | False                                                                    |
+      | uuid                   | 263ff2f1-2f75-4a9a-95aa-b475b9160ec4                                     |
       +------------------------+--------------------------------------------------------------------------+
 
 ## Post-Deployment
@@ -212,26 +212,26 @@ To scale a deployment, first you will need to update the deployment plan and the
 
 First we need to retrieve the Plan ID. This can be seen in the output of `tuskar plan-list` or it can be programmatically retrieved with the following command:
 
-      PLAN_ID=$( tuskar plan-show overcloud | awk '$2=="uuid" {print $4}' )
+      PLAN_ID=$( tuskar plan-show overcloud | awk '$2=="uuid" {print $4}' )
 
 To see the current scale values for your roles, use the `tuskar plan-show` command. Since the output is large, we can focus on the relevant sections with this command. It will show you each of the roles and their autoscale value.
 
-      $ tuskar plan-show overcloud | grep "::count" -A 1
-      |             | name=swift-storage-1::count        |
-      |             | value=1                            |
+      $ tuskar plan-show overcloud | grep "::count" -A 1
+      |             | name=swift-storage-1::count        |
+      |             | value=1                            |
       --
-      |             | name=controller-1::count           |
-      |             | value=1                            |
+      |             | name=controller-1::count           |
+      |             | value=1                            |
       --
-      |             | name=compute-1::count              |
-      |             | value=1                            |
+      |             | name=compute-1::count              |
+      |             | value=1                            |
       --
-      |             | name=cinder-storage-1::count       |
-      |             | value=1                            
+      |             | name=cinder-storage-1::count       |
+      |             | value=1                            
 
 The plan-patch command allows us to set the count for the role we want to scale.
 
-      tuskar plan-patch -A compute-1::count=4 $PLAN_ID
+      tuskar plan-patch -A compute-1::count=4 $PLAN_ID
 
 **Note: At the moment only scaling up is supported.**
 
@@ -239,12 +239,12 @@ The format of the attribute name is the `$ROLE_NAME-$ROLE_VERSION::count`. There
 
 After updating the attribute, we need to output the Heat Orchestration Templates to then send these to Heat. This is done with the `tuskar plan-templates` command by passing an output directory and the Plan ID.
 
-      tuskar plan-templates -O tuskar_templates $PLAN_ID
+      tuskar plan-templates -O tuskar_templates $PLAN_ID
 
 Finally we can perform a stack update with Heat.
 
-      heat stack-update -f "tuskar_templates/plan.yaml" \
-         -e "tuskar_templates/environment.yaml" \
-         overcloud
+      heat stack-update -f "tuskar_templates/plan.yaml" \
+         -e "tuskar_templates/environment.yaml" \
+         overcloud
 
 If there are any problems with the Heat stack update, the Heat engine log under `/var/log/heat/engine.log` is a good place to start debugging.

--- a/source/install/tuskar-cli.html.md
+++ b/source/install/tuskar-cli.html.md
@@ -20,30 +20,30 @@ Once Tuskar has been successfully installed in the undercloud with Instack the f
 
 1. First, initialise the command line enviroment, this will load the credentials and default settings for a deployment.
 
-         source ~/deploy-overcloudrc
-         source ~/tripleo-undercloud-passwords
-         source ~/stackrc
-         source /usr/share/instack-undercloud/deploy-virt-overcloudrc
+         source ~/deploy-overcloudrc
+         source ~/tripleo-undercloud-passwords
+         source ~/stackrc
+         source /usr/share/instack-undercloud/deploy-virt-overcloudrc
 
 2. You are now ready to start the default deployment with the following command.
 
-         instack-deploy-overcloud --tuskar
+         instack-deploy-overcloud --tuskar
 
 The default settings will deploy the control role to one node and the compute role to one node.
 
 3. You can scale your deployment or add new roles easily by defining the number of nodes for a role. The following commands will deploy four roles over four nodes.
 
-         export CONTROLSCALE=1
-         export COMPUTESCALE=1
-         export BLOCKSTORAGESCALE=1
-         export SWIFTSTORAGESCALE=1
-         instack-update-overcloud --tuskar
+         export CONTROLSCALE=1
+         export COMPUTESCALE=1
+         export BLOCKSTORAGESCALE=1
+         export SWIFTSTORAGESCALE=1
+         instack-update-overcloud --tuskar
 
 **Note:** Currenlty scale down is not supported.
 
 4. You can view the state of your baremetal machines and their state with the nova client which is already installed and will be usable after setting up the enviroment in step 1.
 
-         nova baremetal-node-list
+         nova baremetal-node-list
 
 See the [nova documentation](http://docs.openstack.org/cli-reference/content/novaclient_commands.html) for futher details around using the nova client.
 
@@ -55,12 +55,12 @@ The Tuskar command line interface has a number of commands for interacting with 
 
 The tuskar plan-list command wil output a list of all of the plans in the Tuskar API. Currently this is limited to one plan with the name overcloud. Example output from this command can be seen below.
 
-         $ tuskar plan-list
-         +--------------------------------------+-----------+-------------+----------------------------------------------------+
-         | uuid                                 | name      | description | roles                                              |
-         +--------------------------------------+-----------+-------------+----------------------------------------------------+
-         | d9ac81d2-1f69-450d-91d3-64fed8081e8f | overcloud | None        | controller, swift-storage, compute, cinder-storage |
-         +--------------------------------------+-----------+-------------+----------------------------------------------------+
+         $ tuskar plan-list
+         +--------------------------------------+-----------+-------------+----------------------------------------------------+
+         | uuid                                 | name      | description | roles                                              |
+         +--------------------------------------+-----------+-------------+----------------------------------------------------+
+         | d9ac81d2-1f69-450d-91d3-64fed8081e8f | overcloud | None        | controller, swift-storage, compute, cinder-storage |
+         +--------------------------------------+-----------+-------------+----------------------------------------------------+
 
 ### tuskar plan-show
 
@@ -68,23 +68,23 @@ The plan show command will display the full details of your plan and the roles w
 
 usage: tuskar plan-show <PLAN UUID>
 
-        $ tuskar plan-show e09572b6-eed2-41c0-9d98-f7d5d0872ff8
-        +-------------+--------------------------------------------------------------------------------------------------------------------+
-        | Property    | Value                                                                                                              |
-        +-------------+--------------------------------------------------------------------------------------------------------------------+
-        | created_at  | 2015-01-16T14:27:34                                                                                                |
-        | description | My Plan                                                                                                            |
-        | name        | my_plan                                                                                                            |
-        | parameters  | default= `<SNIP DETAILS>`                                                                                            |
-        | roles       | description=OpenStack control plane node. Can be wrapped in a ResourceGroup for scaling.                           |
-        |             |                                                                                                                    |
-        |             | name=controller                                                                                                    |
-        |             | uuid=79caea1a-f8fc-4eee-b663-40f89744382c                                                                          |
-        |             | version=1                                                                                                          |
-        |             |                                                                                                                    |
-        | updated_at  | None                                                                                                               |
-        | uuid        | e09572b6-eed2-41c0-9d98-f7d5d0872ff8                                                                               |
-        +-------------+--------------------------------------------------------------------------------------------------------------------+
+        $ tuskar plan-show e09572b6-eed2-41c0-9d98-f7d5d0872ff8
+        +-------------+--------------------------------------------------------------------------------------------------------------------+
+        | Property    | Value                                                                                                              |
+        +-------------+--------------------------------------------------------------------------------------------------------------------+
+        | created_at  | 2015-01-16T14:27:34                                                                                                |
+        | description | My Plan                                                                                                            |
+        | name        | my_plan                                                                                                            |
+        | parameters  | default= `<SNIP DETAILS>`                                                                                            |
+        | roles       | description=OpenStack control plane node. Can be wrapped in a ResourceGroup for scaling.                           |
+        |             |                                                                                                                    |
+        |             | name=controller                                                                                                    |
+        |             | uuid=79caea1a-f8fc-4eee-b663-40f89744382c                                                                          |
+        |             | version=1                                                                                                          |
+        |             |                                                                                                                    |
+        | updated_at  | None                                                                                                               |
+        | uuid        | e09572b6-eed2-41c0-9d98-f7d5d0872ff8                                                                               |
+        +-------------+--------------------------------------------------------------------------------------------------------------------+
 
 ### tuskar plan-patch
 
@@ -101,14 +101,14 @@ usage: tuskar plan-templates -O
 <OUTPUT DIR>
 plan_uuid
 
-        $ tuskar plan-templates -O templates 344441e0-c2ba-4a0d-a857-51f35057fc53
-        Following templates has been written:
-        templates/plan.yaml
-        templates/environment.yaml
-        templates/provider-swift-storage-1.yaml
-        templates/provider-cinder-storage-1.yaml
-        templates/provider-controller-1.yaml
-        templates/provider-compute-1.yaml
+        $ tuskar plan-templates -O templates 344441e0-c2ba-4a0d-a857-51f35057fc53
+        Following templates has been written:
+        templates/plan.yaml
+        templates/environment.yaml
+        templates/provider-swift-storage-1.yaml
+        templates/provider-cinder-storage-1.yaml
+        templates/provider-controller-1.yaml
+        templates/provider-compute-1.yaml
 
 ### tuskar plan-add-role
 
@@ -116,23 +116,23 @@ Associate role to a plan. The role uuid can be found with 'tuskar role-list'.
 
 usage: tuskar plan-add-role -r <ROLE UUID> plan_uuid
 
-        $ tuskar plan-add-role -r 79caea1a-f8fc-4eee-b663-40f89744382c e09572b6-eed2-41c0-9d98-f7d5d0872ff8
-        +-------------+--------------------------------------------------------------------------------------------------------------------+
-        | Property    | Value                                                                                                              |
-        +-------------+--------------------------------------------------------------------------------------------------------------------+
-        | created_at  | 2015-01-16T14:27:34                                                                                                |
-        | description | My Plan                                                                                                            |
-        | name        | my_plan                                                                                                            |
-        | parameters  | default= ...  `<SNIP DETAILS>`                                                                                       |
-        | roles       | description=OpenStack control plane node. Can be wrapped in a ResourceGroup for scaling.                           |
-        |             |                                                                                                                    |
-        |             | name=controller                                                                                                    |
-        |             | uuid=79caea1a-f8fc-4eee-b663-40f89744382c                                                                          |
-        |             | version=1                                                                                                          |
-        |             |                                                                                                                    |
-        | updated_at  | None                                                                                                               |
-        | uuid        | e09572b6-eed2-41c0-9d98-f7d5d0872ff8                                                                               |
-        +-------------+--------------------------------------------------------------------------------------------------------------------+
+        $ tuskar plan-add-role -r 79caea1a-f8fc-4eee-b663-40f89744382c e09572b6-eed2-41c0-9d98-f7d5d0872ff8
+        +-------------+--------------------------------------------------------------------------------------------------------------------+
+        | Property    | Value                                                                                                              |
+        +-------------+--------------------------------------------------------------------------------------------------------------------+
+        | created_at  | 2015-01-16T14:27:34                                                                                                |
+        | description | My Plan                                                                                                            |
+        | name        | my_plan                                                                                                            |
+        | parameters  | default= ...  `<SNIP DETAILS>`                                                                                       |
+        | roles       | description=OpenStack control plane node. Can be wrapped in a ResourceGroup for scaling.                           |
+        |             |                                                                                                                    |
+        |             | name=controller                                                                                                    |
+        |             | uuid=79caea1a-f8fc-4eee-b663-40f89744382c                                                                          |
+        |             | version=1                                                                                                          |
+        |             |                                                                                                                    |
+        | updated_at  | None                                                                                                               |
+        | uuid        | e09572b6-eed2-41c0-9d98-f7d5d0872ff8                                                                               |
+        +-------------+--------------------------------------------------------------------------------------------------------------------+
 
 ### tuskar plan-create
 
@@ -142,18 +142,18 @@ usage: tuskar plan-create [-d <DESCRIPTION>] name
 
 Where name is the name of the plan to create. Description is an optional argument specifying a user-readable text for describing the Plan.
 
-        $ tuskar plan-create -d 'My Plan' my_plan
-        +-------------+--------------------------------------+
-        | Property    | Value                                |
-        +-------------+--------------------------------------+
-        | created_at  | 2015-01-16T14:27:34                  |
-        | description | My Plan                              |
-        | name        | my_plan                              |
-        | parameters  |                                      |
-        | roles       |                                      |
-        | updated_at  | None                                 |
-        | uuid        | e09572b6-eed2-41c0-9d98-f7d5d0872ff8 |
-        +-------------+--------------------------------------+
+        $ tuskar plan-create -d 'My Plan' my_plan
+        +-------------+--------------------------------------+
+        | Property    | Value                                |
+        +-------------+--------------------------------------+
+        | created_at  | 2015-01-16T14:27:34                  |
+        | description | My Plan                              |
+        | name        | my_plan                              |
+        | parameters  |                                      |
+        | roles       |                                      |
+        | updated_at  | None                                 |
+        | uuid        | e09572b6-eed2-41c0-9d98-f7d5d0872ff8 |
+        +-------------+--------------------------------------+
 
 ### tuskar plan-delete
 
@@ -161,8 +161,8 @@ Delete a plan given a UUID.
 
 usage: tuskar plan-delete <PLAN UUID>
 
-        $ tuskar plan-delete e09572b6-eed2-41c0-9d98-f7d5d0872ff8
-        Deleted Plan "my_plan".
+        $ tuskar plan-delete e09572b6-eed2-41c0-9d98-f7d5d0872ff8
+        Deleted Plan "my_plan".
 
 ### tuskar plan-remove-role
 
@@ -170,34 +170,34 @@ Remove role from a plan.
 
 usage: tuskar plan-remove-role -r <ROLE UUID> <PLAN UUID>
 
-        $ tuskar plan-remove-role -r 79caea1a-f8fc-4eee-b663-40f89744382c e09572b6-eed2-41c0-9d98-f7d5d0872ff8           
-        +-------------+--------------------------------------------------------------------------------------------------------------------+
-        | Property    | Value                                                                                                              |
-        +-------------+--------------------------------------------------------------------------------------------------------------------+
-        | created_at  | 2015-01-16T14:27:34                                                                                                |
-        | description | My Plan                                                                                                            |
-        | name        | my_plan                                                                                                            |
-        | parameters  | default= `<SNIP DETAILS>`                                                                                            |
-        | roles       |                                                                                                                    |
-        | updated_at  | None                                                                                                               |
-        | uuid        | e09572b6-eed2-41c0-9d98-f7d5d0872ff8                                                                               |
-        +-------------+--------------------------------------------------------------------------------------------------------------------+
+        $ tuskar plan-remove-role -r 79caea1a-f8fc-4eee-b663-40f89744382c e09572b6-eed2-41c0-9d98-f7d5d0872ff8           
+        +-------------+--------------------------------------------------------------------------------------------------------------------+
+        | Property    | Value                                                                                                              |
+        +-------------+--------------------------------------------------------------------------------------------------------------------+
+        | created_at  | 2015-01-16T14:27:34                                                                                                |
+        | description | My Plan                                                                                                            |
+        | name        | my_plan                                                                                                            |
+        | parameters  | default= `<SNIP DETAILS>`                                                                                            |
+        | roles       |                                                                                                                    |
+        | updated_at  | None                                                                                                               |
+        | uuid        | e09572b6-eed2-41c0-9d98-f7d5d0872ff8                                                                               |
+        +-------------+--------------------------------------------------------------------------------------------------------------------+
 
 ### tuskar role-list
 
 The role list command will display the roles that are available to be added to a plan. This command takes no arguments.
 
-        $ tuskar role-list
-        +--------------------------------------+----------------+---------+----------------------------------------------------------------+
-        | uuid                                 | name           | version | description                                                    |
-        +--------------------------------------+----------------+---------+----------------------------------------------------------------+
-        | 0932afdb-39b3-41bc-b530-359e487e79e4 | compute        | 1       | OpenStack hypervisor node. Can be wrapped in a ResourceGroup fo|
-        |                                      |                |         | r scaling.                                                     |
-        | 62e7ca60-98a4-4231-b793-9d546c2bd1c9 | cinder-storage | 1       | Common Block Storage Configuration                             |
-        | 79caea1a-f8fc-4eee-b663-40f89744382c | controller     | 1       | OpenStack control plane node. Can be wrapped in a ResourceGroup|
-        |                                      |                |         | for scaling.                                                   |
-        | b106841c-6fbe-4a78-afff-3cfccb509861 | swift-storage  | 1       | Common Swift Storage Configuration                             |
-        +--------------------------------------+----------------+---------+----------------------------------------------------------------+
+        $ tuskar role-list
+        +--------------------------------------+----------------+---------+----------------------------------------------------------------+
+        | uuid                                 | name           | version | description                                                    |
+        +--------------------------------------+----------------+---------+----------------------------------------------------------------+
+        | 0932afdb-39b3-41bc-b530-359e487e79e4 | compute        | 1       | OpenStack hypervisor node. Can be wrapped in a ResourceGroup fo|
+        |                                      |                |         | r scaling.                                                     |
+        | 62e7ca60-98a4-4231-b793-9d546c2bd1c9 | cinder-storage | 1       | Common Block Storage Configuration                             |
+        | 79caea1a-f8fc-4eee-b663-40f89744382c | controller     | 1       | OpenStack control plane node. Can be wrapped in a ResourceGroup|
+        |                                      |                |         | for scaling.                                                   |
+        | b106841c-6fbe-4a78-afff-3cfccb509861 | swift-storage  | 1       | Common Swift Storage Configuration                             |
+        +--------------------------------------+----------------+---------+----------------------------------------------------------------+
 
 ## Advanced Usage
 
@@ -205,28 +205,28 @@ In the quick usage above, we rely on instack for most of the interactions with T
 
 1. First initialise the command line enviroment, this will load the credentials and default settings for a deployment.
 
-         source ~/deploy-overcloudrc
-         source ~/tripleo-undercloud-passwords
-         source ~/stackrc
-         source /usr/share/instack-undercloud/deploy-virt-overcloudrc
+         source ~/deploy-overcloudrc
+         source ~/tripleo-undercloud-passwords
+         source ~/stackrc
+         source /usr/share/instack-undercloud/deploy-virt-overcloudrc
 
 2. We need to retrieve the Plan ID from the API which will then be used for future communication with the API. This command can also be used to verify that the roles have been added to the deployment plan.
 
-         tuskar plan-list
+         tuskar plan-list
 
 3. You will then need to update the the plan to set the attributes required by each role. This can be done with the following command.
 
-         tuskar plan-patch -A $KEY=$VALUE $PLAN_ID
+         tuskar plan-patch -A $KEY=$VALUE $PLAN_ID
 
 4. After the plan has been configured, you can retrieve the full plan as Heat Orchestration Templates with the following command.
 
-         tuskar plan-templates -o tuskar_templates $PLAN_ID
+         tuskar plan-templates -o tuskar_templates $PLAN_ID
 
 5. You should now be ready to send the plan to Heat. This can be done with the following command.
 
-         heat stack-create \
-             -f tuskar_templates/plan.yml \
-             -e tuskar_templates/environment.yml \
-             overcloud
+         heat stack-create \
+             -f tuskar_templates/plan.yml \
+             -e tuskar_templates/environment.yml \
+             overcloud
 
 See the [Heat client documentation](http://docs.openstack.org/user-guide-admin/content/heat_client_commands.html) for more details on it's usage.

--- a/source/install/tuskar-ui.html.md
+++ b/source/install/tuskar-ui.html.md
@@ -159,7 +159,7 @@ If you wish to create a development installation of the Tuskar-UI, install as de
 
 Next, turn off the running instance of the Tuskar UI:
 
-       sudo service httpd stop
+       sudo service httpd stop
 
 Now you can follow the [development instance installation instructions](http://tuskar-ui.readthedocs.org/en/latest/install.html).
 
@@ -173,32 +173,32 @@ Use the Tuskar CLI to modify additional parameters. This process is described in
 
 The Tuskar CLI can be used to perform additional operations. In order to use it, access the Instack virtual machine and source stackrc:
 
-       source /home/stack/stackrc
+       source /home/stack/stackrc
 
 Many of the CLI operations require the overcloud plan uuid:
 
-       [stack@localhost ~]$ tuskar plan-list
-       +--------------------------------------+-----------+-------------+----------------------------------------------------+
-       | uuid                                 | name      | description | roles                                              |
-       +--------------------------------------+-----------+-------------+----------------------------------------------------+
-       | 1289d499-de0a-4688-86e2-b0caf7ae06ea | overcloud | None        | controller, swift-storage, compute, cinder-storage |
-       +--------------------------------------+-----------+-------------+----------------------------------------------------+
+       [stack@localhost ~]$ tuskar plan-list
+       +--------------------------------------+-----------+-------------+----------------------------------------------------+
+       | uuid                                 | name      | description | roles                                              |
+       +--------------------------------------+-----------+-------------+----------------------------------------------------+
+       | 1289d499-de0a-4688-86e2-b0caf7ae06ea | overcloud | None        | controller, swift-storage, compute, cinder-storage |
+       +--------------------------------------+-----------+-------------+----------------------------------------------------+
 
 #### View Overcloud templates
 
 To view the Heat templates used for the Overcloud deployment, run the following:
 
-` [stack@localhost ~]$ tuskar plan-templates -O output-dir `<plan uuid>
-       Following templates has been written:
-       output-dir/plan.yaml
-       output-dir/environment.yaml
-       output-dir/provider-swift-storage-1.yaml
-       output-dir/provider-cinder-storage-1.yaml
-       output-dir/provider-controller-1.yaml
-       output-dir/provider-compute-1.yaml
+` [stack@localhost ~]$ tuskar plan-templates -O output-dir `<plan uuid>
+       Following templates has been written:
+       output-dir/plan.yaml
+       output-dir/environment.yaml
+       output-dir/provider-swift-storage-1.yaml
+       output-dir/provider-cinder-storage-1.yaml
+       output-dir/provider-controller-1.yaml
+       output-dir/provider-compute-1.yaml
 
 #### Modify Overcloud parameters
 
 Available Overcloud parameters can be viewed in the environment.yaml file. To modify a specific parameter, run the following:
 
-` [stack@localhost ~]$ tuskar plan-patch -A `<key>`=`<value>` `<plan uuid>
+` [stack@localhost ~]$ tuskar plan-patch -A `<key>`=`<value>` `<plan uuid>

--- a/source/networking/ml2-plugin.html.md
+++ b/source/networking/ml2-plugin.html.md
@@ -31,61 +31,61 @@ The remaining steps are all executed as root on the neutron controller node(s) w
 
 Stop neutron-server:
 
-      service neutron-server stop
+      service neutron-server stop
 
 Install the ML2 plugin:
 
-      yum install openstack-neutron-ml2
+      yum install openstack-neutron-ml2
 
 Switch to ML2's config file:
 
-      [ -h /etc/neutron/plugin.ini ] && unlink /etc/neutron/plugin.ini
-      ln -s /etc/neutron/plugins/ml2/ml2_conf.ini /etc/neutron/plugin.ini
+      [ -h /etc/neutron/plugin.ini ] && unlink /etc/neutron/plugin.ini
+      ln -s /etc/neutron/plugins/ml2/ml2_conf.ini /etc/neutron/plugin.ini
 
 Configure neutron-server to load the ML2 core plugin and the L3Router service plugin:
 
-      crudini --set /etc/neutron/neutron.conf DEFAULT core_plugin neutron.plugins.ml2.plugin.Ml2Plugin
-      crudini --set /etc/neutron/neutron.conf DEFAULT service_plugins neutron.services.l3_router.l3_router_plugin.L3RouterPlugin
+      crudini --set /etc/neutron/neutron.conf DEFAULT core_plugin neutron.plugins.ml2.plugin.Ml2Plugin
+      crudini --set /etc/neutron/neutron.conf DEFAULT service_plugins neutron.services.l3_router.l3_router_plugin.L3RouterPlugin
 
 Note - if you are using LBaaS, FWaaS, or VPNaaS, you will also need to include them in service_plugins.
 
 Configure ML2:
 
-      crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 mechanism_drivers openvswitch
-`crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 tenant_network_types `<one or more of local,vlan,gre,vxlan>
-      crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini database sql_connection mysql://neutron:`<password>`@`<host>`/neutron_ml2
-      crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini securitygroup firewall_driver dummy_value_to_enable_security_groups_in_server
+      crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 mechanism_drivers openvswitch
+`crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 tenant_network_types `<one or more of local,vlan,gre,vxlan>
+      crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini database sql_connection mysql://neutron:`<password>`@`<host>`/neutron_ml2
+      crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini securitygroup firewall_driver dummy_value_to_enable_security_groups_in_server
 
 If using VLAN provider and/or tenant networks, configure the VlanTypeDriver:
 
-` crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2_type_vlan network_vlan_ranges `<same range syntax as openvswitch>
+` crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2_type_vlan network_vlan_ranges `<same range syntax as openvswitch>
 
 If using flat provider networks, configure the FlatTypeDriver:
 
-` crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2_type_flat flat_networks `<list of physical_networks or *>
+` crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2_type_flat flat_networks `<list of physical_networks or *>
 
 If using GRE tenant networks, configure the GreTypeDriver:
 
-` crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2_type_gre tunnel_id_ranges `<list of ranges>
+` crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2_type_gre tunnel_id_ranges `<list of ranges>
 
 If using VXLAN tenant networks, configure the VxlanTypeDriver:
 
-` crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2_type_vxlan vni_ranges `<list of ranges>
+` crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2_type_vxlan vni_ranges `<list of ranges>
 
 Once everything is properly configured, but before starting neutron-server, create the ML2 database:
 
-      mysql -e "drop database if exists neutron_ml2;"
-      mysql -e "create database neutron_ml2 character set utf8;"
-      mysql -e "grant all on neutron_ml2.* to 'neutron'@'%';"
-      neutron-db-manage --config-file /usr/share/neutron/neutron-dist.conf --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugin.ini upgrade head
+      mysql -e "drop database if exists neutron_ml2;"
+      mysql -e "create database neutron_ml2 character set utf8;"
+      mysql -e "grant all on neutron_ml2.* to 'neutron'@'%';"
+      neutron-db-manage --config-file /usr/share/neutron/neutron-dist.conf --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugin.ini upgrade head
 
 Finally, start neutron-server:
 
-      service neutron-server start
+      service neutron-server start
 
 Check /var/log/neutron/server.log and make sure it started OK. Then run the following with admin credentials to make sure neutron-server is communicating with its agents:
 
-      neutron agent-list
+      neutron agent-list
 
 You should see "Open vSwitch agent" alive on all compute and network nodes, as well as all other agents (DHCP, L3, LBaaS) you've deployed.
 

--- a/source/networking/multi-node-openstack-with-neutron-with-libvirt,-netsted-kvm,-virt-manager-and-qcow2-images.html.md
+++ b/source/networking/multi-node-openstack-with-neutron-with-libvirt,-netsted-kvm,-virt-manager-and-qcow2-images.html.md
@@ -128,7 +128,7 @@ NOTE: Repository mirroring isn't in the scope of this document, but if you are n
     reposync -n -c yum.conf
     for i in */;do createrepo -c cache $i;done.
 
-      and a quick and dirty way to serve them up is:
+      and a quick and dirty way to serve them up is:
 
     sudo python -m SimpleHTTPServer 80
 

--- a/source/networking/neutron-gbp.html.md
+++ b/source/networking/neutron-gbp.html.md
@@ -24,52 +24,52 @@ Start with a working Packstack installation with Neutron, such as is described i
 
 Install the server and client RPMs:
 
-      yum install openstack-neutron-gbp
-      yum install python-gbpclient
+      yum install openstack-neutron-gbp
+      yum install python-gbpclient
 
 Stop the Neutron server:
 
-      systemctl stop neutron-server
+      systemctl stop neutron-server
 
 Edit the Neutron configuration to include the GBP service plugin and its reference policy drivers:
 
-      ` crudini --set /etc/neutron/neutron.conf DEFAULT service_plugins "`crudini --get /etc/neutron/neutron.conf DEFAULT service_plugins`,group_policy" `
-      crudini --set /etc/neutron/neutron.conf group_policy policy_drivers "implicit_policy,resource_mapping"
+      ` crudini --set /etc/neutron/neutron.conf DEFAULT service_plugins "`crudini --get /etc/neutron/neutron.conf DEFAULT service_plugins`,group_policy" `
+      crudini --set /etc/neutron/neutron.conf group_policy policy_drivers "implicit_policy,resource_mapping"
 
 Update the Neutron DB schema to include the GBP tables:
 
-      gbp-db-manage --config-file /usr/share/neutron/neutron-dist.conf --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugin.ini upgrade head
+      gbp-db-manage --config-file /usr/share/neutron/neutron-dist.conf --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugin.ini upgrade head
 
 Start the Neutron server and check its status:
 
-      systemctl start neutron-server
-      systemctl status neutron-server
+      systemctl start neutron-server
+      systemctl status neutron-server
 
 ### Configuring Horizon
 
 Install the RPMs:
 
-       yum install openstack-dashboard-gbp
+       yum install openstack-dashboard-gbp
 
 Restart the web server and check its status:
 
-      systemctl restart httpd
-      systemctl status httpd
+      systemctl restart httpd
+      systemctl status httpd
 
 ### Configuring Heat
 
 Assuming Heat is enabled in your RDO deployment, install the RPM:
 
-      yum install openstack-heat-gbp
+      yum install openstack-heat-gbp
 
 Edit the Heat configuration to include the GBP plugin:
 
-      crudini --set /etc/heat/heat.conf DEFAULT plugin_dirs "/usr/lib64/heat,/usr/lib/heat,/usr/lib/python2.7/site-packages/gbpautomation/heat"
+      crudini --set /etc/heat/heat.conf DEFAULT plugin_dirs "/usr/lib64/heat,/usr/lib/heat,/usr/lib/python2.7/site-packages/gbpautomation/heat"
 
 Restart the Heat engine and check its status:
 
-      systemctl restart openstack-heat-engine
-      systemctl status openstack-heat-engine
+      systemctl restart openstack-heat-engine
+      systemctl status openstack-heat-engine
 
 ## Using GBP
 
@@ -77,27 +77,27 @@ Once the neutron server is configured with GBP and running, basic operation can 
 
 Create a group:
 
-      gbp group-create test1 --description "first test group"
+      gbp group-create test1 --description "first test group"
 
 The response should show the details of the group.
 
 List the groups:
 
-      gbp group-list
+      gbp group-list
 
 You should see the group you just created.
 
 Verify that implicit L2 and L3 policies were created:
 
-      gbp l2policy-list
-      gbp l3policy-list
+      gbp l2policy-list
+      gbp l3policy-list
 
 You should see an L2 policy with the same name as the group, and an L3 policy named "default".
 
 Verify that neutron resources were created:
 
-      neutron net-list
-      neutron subnet-list
+      neutron net-list
+      neutron subnet-list
 
 You should see a network and a subnet with names derived from the group name.
 

--- a/source/networking/opendaylight-integration.html.md
+++ b/source/networking/opendaylight-integration.html.md
@@ -20,8 +20,8 @@ Get OpenDaylight virtualization edition from [OpenDaylight Release Download](htt
 
 Both OpenStack Swift and OpenDaylight use port 8080 for webpage GUI. You can either disable OpenStack swift or move OpenDaylight webserver to different port. To move ODL webserver to different port, edit *Connector port* value in configuration/tomcat-server.xml under opendaylight directory:
 
-` `<Service name="Catalina">
-`     `<Connector port="8081" protocol="HTTP/1.1"
+` `<Service name="Catalina">
+`     `<Connector port="8081" protocol="HTTP/1.1"
                      connectionTimeout="20000"
                                     redirectPort="8443" />
 
@@ -31,7 +31,7 @@ Make sure it has following line for OpenFlow 1.3 config in the configuration/con
 
 Start the controller with OVSDB and OpenFlow 1.3 option
 
-      ./run.sh -virt ovsdb -of13
+      ./run.sh -virt ovsdb -of13
 
 ## Configure ovsdb to connect to OpenDaylight and provide network information
 
@@ -44,7 +44,7 @@ The odl.sh script below accomplishes a few things:
 
 Copy the odl.sh script and run it as:
 
-      sudo ./odl.sh --local_ip 192.168.120.31 --provider_mappings physnet1:eth1,physnet3:eth3 --odl_ip 192.168.120.1
+      sudo ./odl.sh --local_ip 192.168.120.31 --provider_mappings physnet1:eth1,physnet3:eth3 --odl_ip 192.168.120.1
 
 Modify the values to match your configuration. For example, --provider_mappings is not needed if vlan tenant isolation is not used.
 
@@ -56,11 +56,11 @@ Start RDO as suggested in [ RDO Quickstart](Quickstart). After OpenStack is up a
 
 Stop neutron server
 
-      service neutron-server stop
+      service neutron-server stop
 
 Stop openvswitch agent on all aompute nodes
 
-      service neutron-openvswitch-agent stop
+      service neutron-openvswitch-agent stop
 
 Download the [OpenDaylight driver for ML2 plugin](https://raw.github.com/CiscoSystems/neutron/odl_ml2/neutron/plugins/ml2/drivers/mechanism_odl.py) and put the driver file under /usr/lib/python2.7/site-packages/neutron/plugins/ml2/drivers/ or /usr/lib/python2.6/site-packages/neutron/plugins/ml2/drivers/ if using RHEL 6.5.
 
@@ -70,17 +70,17 @@ If using OpenStack Havana, you need to change neutron constants import and egg-i
 
 1. remove following line in downloaded OpenDaylight driver:
 
-      from neutron.plugins.openvswitch.common import constants
+      from neutron.plugins.openvswitch.common import constants
 
 And add this line in OpenDaylight driver to change constants import :
 
-      from neutron.openstack.common import constants
+      from neutron.openstack.common import constants
 
 2. Modification in egg-info is also required for using OpenStack Havana, Add entry point in /usr/lib/python2.6/site-packages/neutron-2013.2.1-py2.6.egg-info/entry_points.txt
 
       [neutron.ml2.mechanism_drivers]
       ...
-      opendaylight = neutron.plugins.ml2.drivers.mechanism_odl:OpenDaylightMechanismDriver
+      opendaylight = neutron.plugins.ml2.drivers.mechanism_odl:OpenDaylightMechanismDriver
 
 ------------------------------------------------------------------------
 
@@ -116,48 +116,48 @@ Based on that change `neutron/neutron/plugins/ml2/drivers/mechanism_odl.py` cons
 
 Modify /etc/neutron/plugins/ml2/ml2_conf.ini in Openstack control node:
 
-      crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 mechanism_drivers opendaylight 
-`crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 tenant_network_types `<gre or vxlan>
+      crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 mechanism_drivers opendaylight 
+`crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 tenant_network_types `<gre or vxlan>
 
 Configure the odl section in /etc/neutron/plugins/ml2/ml2_conf.ini in Openstack control node
 
       [odl]
-      nodes = 
-`network_vlan_ranges = `<vlan_min>`:`<vlan_max>
-`tunnel_id_ranges = `<tunnel_id_min>`:`<tunnel_id_max>
-      tun_peer_patch_port = patch-int
-      int_peer_patch_port = patch-tun
-      tenant_network_type = vlan
-      tunnel_bridge = br-tun
-      integration_bridge = br-int
-      controllers = `<ODL_controller_ip>`:`<ODL_controller_port>`:admin:admin
+      nodes = 
+`network_vlan_ranges = `<vlan_min>`:`<vlan_max>
+`tunnel_id_ranges = `<tunnel_id_min>`:`<tunnel_id_max>
+      tun_peer_patch_port = patch-int
+      int_peer_patch_port = patch-tun
+      tenant_network_type = vlan
+      tunnel_bridge = br-tun
+      integration_bridge = br-int
+      controllers = `<ODL_controller_ip>`:`<ODL_controller_port>`:admin:admin
 
 Configure the ml2_odl section in /etc/neutron/plugins/ml2_conf.ini in Openstack control node
 
       [ml2_odl]
-      password = admin
-      username = admin
-      url = `[`http://`](http://)<ODL_controller_ip>`:`<ODL_controller_port>`/controller/nb/v2/neutron
+      password = admin
+      username = admin
+      url = `[`http://`](http://)<ODL_controller_ip>`:`<ODL_controller_port>`/controller/nb/v2/neutron
 
 There is no change required at Openstack compute node. Example of ml2_conf.ini file including above changes can also be find [here](http://paste.openstack.org/show/61851/).
 
 Once everything is properly configured, but before starting neutron-server, recreate the ML2 database:
 
-      mysql -e "drop database if exists neutron_ml2;"
-      mysql -e "create database neutron_ml2 character set utf8;"
-      mysql -e "grant all on neutron_ml2.* to 'neutron'@'%';"
-      neutron-db-manage --config-file /usr/share/neutron/neutron-dist.conf --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugin.ini upgrade head
+      mysql -e "drop database if exists neutron_ml2;"
+      mysql -e "create database neutron_ml2 character set utf8;"
+      mysql -e "grant all on neutron_ml2.* to 'neutron'@'%';"
+      neutron-db-manage --config-file /usr/share/neutron/neutron-dist.conf --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugin.ini upgrade head
 
 Start neutron server
 
-      service neutron-server start
+      service neutron-server start
 
 ## Create network and launch VM instances
 
 Create network and attach subnet by neutron commands
 
-`neutron net-create `<network name>` --provider:network_type `<gre or vxlan>` --provider:segmentation_id `<id>
-      neutron  subnet-create `<network name>`10.100.2.0/24 --name `<subnet name>` 
+`neutron net-create `<network name>` --provider:network_type `<gre or vxlan>` --provider:segmentation_id `<id>
+      neutron  subnet-create `<network name>`10.100.2.0/24 --name `<subnet name>` 
 
 Add VM instance to the subnet by [ running instances](Running_an_instance). VM on different compute nodes should be able to ping each other through GRE or VxLAN tunnels provisioned by ODL controller.
 

--- a/source/networking/using-gre-tenant-networks.html.md
+++ b/source/networking/using-gre-tenant-networks.html.md
@@ -41,19 +41,19 @@ The above assumes a provider external network is being used. If an external brid
 
 If modifying an existing deployment to use GRE tenant networks, run the following on the controller node:
 
-      # openstack-config --set /etc/quantum/plugins/openvswitch/ovs_quantum_plugin.ini OVS tenant_network_type gre
+      # openstack-config --set /etc/quantum/plugins/openvswitch/ovs_quantum_plugin.ini OVS tenant_network_type gre
 
 Then, for either a new or existing deployment, run these commands on the controller node:
 
-      # openstack-config --set /etc/quantum/plugins/openvswitch/ovs_quantum_plugin.ini OVS enable_tunneling True
-      # openstack-config --set /etc/quantum/plugins/openvswitch/ovs_quantum_plugin.ini OVS tunnel_id_ranges 1:1000
-      # service quantum-server restart
+      # openstack-config --set /etc/quantum/plugins/openvswitch/ovs_quantum_plugin.ini OVS enable_tunneling True
+      # openstack-config --set /etc/quantum/plugins/openvswitch/ovs_quantum_plugin.ini OVS tunnel_id_ranges 1:1000
+      # service quantum-server restart
 
 Finally, on each node where quantum-openvswitch-agent runs (all compute and network nodes), run:
 
-      # openstack-config --set /etc/quantum/plugins/openvswitch/ovs_quantum_plugin.ini OVS enable_tunneling True
-`# openstack-config --set /etc/quantum/plugins/openvswitch/ovs_quantum_plugin.ini OVS local_ip `<IP address>
-      # service quantum-openvswitch-agent restart
+      # openstack-config --set /etc/quantum/plugins/openvswitch/ovs_quantum_plugin.ini OVS enable_tunneling True
+`# openstack-config --set /etc/quantum/plugins/openvswitch/ovs_quantum_plugin.ini OVS local_ip `<IP address>
+      # service quantum-openvswitch-agent restart
 
 ## MTU
 
@@ -65,12 +65,12 @@ You should turn offloading such as TSO/LRO and GRO/GSO off on the instance physi
 
 This can be done with this command (replace ethX with your physical network interface name):
 
-      ethtool -K ethX tso off lro off gro off gso off
+      ethtool -K ethX tso off lro off gro off gso off
 
 You can modify the network script for this change to apply on startup:
 
       /etc/sysconfig/network-scripts/ifcfg-eth0
-      ETHTOOL_OPTS="-K ${DEVICE}  tso off lro off gro off gso off"
+      ETHTOOL_OPTS="-K ${DEVICE}  tso off lro off gro off gso off"
 
 ## Additional Configuration
 
@@ -82,6 +82,6 @@ New packstack deployments can specify the interface whose IP address will be use
 
 Once the above steps are complete, newly created tenant networks should be GRE tunnels, which can be verified by running the following with admin credentials and looking at the provider:network_type attribute:
 
-`# quantum net-show `<network name or UUID>
+`# quantum net-show `<network name or UUID>
 
 <Category:Networking>

--- a/source/tripleo/architecture-overview.html.md
+++ b/source/tripleo/architecture-overview.html.md
@@ -107,33 +107,33 @@ For many users, the simplest way to read and update a deployment plan will be vi
 
 In a default installation of TripleO, there’s a single pre-loaded deployment plan in Tuskar. The details can be retrieved with this command on the deployment cloud node:
 
-`curl -v -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' `[`http://0.0.0.0:8585/v2/plans/`](http://0.0.0.0:8585/v2/plans/)
+`curl -v -X GET -H 'Content-Type: application/json' -H 'Accept: application/json' `[`http://0.0.0.0:8585/v2/plans/`](http://0.0.0.0:8585/v2/plans/)
 
 There’s a large amount of output, the majority of which is the array of parameters which the deployment plans contain, these cover multiple passwords, some usernames, networking options, the name of the flavor to request when creating an instance of a particular role etc..
 
 On the command line, the complete set of details of a plan, including all the parameters, can be seen by first, retrieving the plan ID:
 
-      [stack@localhost ~]$ tuskar plan-list
+      [stack@localhost ~]$ tuskar plan-list
       +--------------------------------------+-----------+-------------+----------------------------------------------------+
-      | uuid                                 | name      | description | roles                                              |
+      | uuid                                 | name      | description | roles                                              |
       +--------------------------------------+-----------+-------------+----------------------------------------------------+
-      | 193f7d1d-a1a9-4605-a54f-2c4ead45a7ab | overcloud | None        | controller, swift-storage, compute, cinder-storage |
+      | 193f7d1d-a1a9-4605-a54f-2c4ead45a7ab | overcloud | None        | controller, swift-storage, compute, cinder-storage |
       +--------------------------------------+-----------+-------------+----------------------------------------------------+
 
 and then by using the uuid for the default plan to run:
 
-      [stack@localhost ~]$ tuskar plan-show 193f7d1d-a1a9-4605-a54f-2c4ead45a7ab
+      [stack@localhost ~]$ tuskar plan-show 193f7d1d-a1a9-4605-a54f-2c4ead45a7ab
 
 That command lists a lot of output, including all the plan’s set of parameters.
 
 It is possible to alter the parameters associated with a plan, via the command line, or via the REST API. The following command increases the number of instances of the “compute” role which the plan will deploy to 6:
 
-      tuskar plan-patch -A compute-1::count=6 193f7d1d-a1a9-4605-a54f-2c4ead45a7ab
+      tuskar plan-patch -A compute-1::count=6 193f7d1d-a1a9-4605-a54f-2c4ead45a7ab
 
 Once the deployment plan is complete, it’s ready to be passed to Heat, the service which actually launches the workload cloud. The command-line tools for Heat consume yaml files. Those yaml files, containing the whole deployment, can be output from Tuskar with this command:
 
-      [stack@localhost tmp]$ tuskar plan-templates -O /tmp 193f7d1d-a1a9-4605-a54f-2c4ead45a7ab
-      Following templates has been written:
+      [stack@localhost tmp]$ tuskar plan-templates -O /tmp 193f7d1d-a1a9-4605-a54f-2c4ead45a7ab
+      Following templates has been written:
       /tmp/plan.yaml
       /tmp/environment.yaml
       /tmp/provider-swift-storage-1.yaml
@@ -151,7 +151,7 @@ Heat’s own term for the applications that it creates is stack. The workload cl
 
 Creating the stack with the CLI can be done like this:
 
-      [stack@localhost tmp]$ heat stack create -f tuskar_templates/plan.yaml -e tuskar_templates/environment.yaml
+      [stack@localhost tmp]$ heat stack create -f tuskar_templates/plan.yaml -e tuskar_templates/environment.yaml
 
 In order to the stack to be deployed, Heat makes successive calls to Nova, OpenStack’s compute service controller. Nova depends upon Ironic,which, as described above has acquired an inventory of discovered hardware by this stage in the process
 
@@ -163,11 +163,11 @@ Once the nodes are booted, Heat also manages passing parameters to the newly lau
 
 The status of the deploying stack, and the completion of the deployment can be seen with this command:
 
-      [stack@localhost ~]$ heat stack-list
+      [stack@localhost ~]$ heat stack-list
       +--------------------------------------+------------+-----------------+----------------------+
-      | id                                   | stack_name | stack_status    | creation_time        |
+      | id                                   | stack_name | stack_status    | creation_time        |
       +--------------------------------------+------------+-----------------+----------------------+
-      | 5b5dc570-c62c-4026-aa70-098c1ac383cb | overcloud  | CREATE_COMPLETE | 2015-03-12T20:15:16Z |
+      | 5b5dc570-c62c-4026-aa70-098c1ac383cb | overcloud  | CREATE_COMPLETE | 2015-03-12T20:15:16Z |
       +--------------------------------------+------------+-----------------+----------------------+
 
 “heat stack-show” will return a complete description of the state of the cloud.
@@ -186,61 +186,61 @@ The metrics which Ceilometer gathers can be queried for Ceilometer's REST API, o
 
 The first stage is to get the Instance UUID which will be used to identify the node we want to report on:
 
-      [stack@localhost ~]$ ironic node-list
+      [stack@localhost ~]$ ironic node-list
       +--------------------------------------+--------------------------------------+-------------+--------------------+-------------+
-      | UUID                                 | Instance UUID                        | Power State | Provisioning State | Maintenance |
+      | UUID                                 | Instance UUID                        | Power State | Provisioning State | Maintenance |
       +--------------------------------------+--------------------------------------+-------------+--------------------+-------------+
-      | 15739d49-90ab-4a42-9620-fe140f5bdcb5 | 9282131d-5e25-495c-82ce-dcbcd34158f7 | power on    | active             | False       |
-      | 3fb4021c-5a79-47ca-af39-f0dcde7109a4 | 31fac73a-90d0-44ef-b3ef-014b43f735e8 | power on    | active             | False       |
-      | 4c9915f1-8f6e-4110-85e3-6dcb8539f51d | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | power on    | active             | False       |
-      | 3ef1e9e9-9f6b-4bbd-aab1-dd0941fb1ae1 | 0a00e394-be74-45b2-9046-1d81dac3d4a4 | power on    | active             | False       |
+      | 15739d49-90ab-4a42-9620-fe140f5bdcb5 | 9282131d-5e25-495c-82ce-dcbcd34158f7 | power on    | active             | False       |
+      | 3fb4021c-5a79-47ca-af39-f0dcde7109a4 | 31fac73a-90d0-44ef-b3ef-014b43f735e8 | power on    | active             | False       |
+      | 4c9915f1-8f6e-4110-85e3-6dcb8539f51d | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | power on    | active             | False       |
+      | 3ef1e9e9-9f6b-4bbd-aab1-dd0941fb1ae1 | 0a00e394-be74-45b2-9046-1d81dac3d4a4 | power on    | active             | False       |
       +--------------------------------------+--------------------------------------+-------------+--------------------+-------------+
 
 Having looked up the nodes, we can then look up the available meters for that node:
 
-      [stack@localhost ~]$ ceilometer meter-list --query resource=d52ebd4f-a28b-49cf-8adc-61847e6bb525
+      [stack@localhost ~]$ ceilometer meter-list --query resource=d52ebd4f-a28b-49cf-8adc-61847e6bb525
       +------------------------------------------+------------+-----------+--------------------------------------+---------+------------+
-      | Name                                     | Type       | Unit      | Resource ID                          | User ID | Project ID |
+      | Name                                     | Type       | Unit      | Resource ID                          | User ID | Project ID |
       +------------------------------------------+------------+-----------+--------------------------------------+---------+------------+
-      | hardware.cpu.load.15min                  | gauge      | process   | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.cpu.load.1min                   | gauge      | process   | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.cpu.load.5min                   | gauge      | process   | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.memory.swap.avail               | gauge      | B         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.memory.swap.total               | gauge      | B         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.memory.total                    | gauge      | B         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.memory.used                     | gauge      | B         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.network.ip.incoming.datagrams   | cumulative | datagrams | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.network.ip.outgoing.datagrams   | cumulative | datagrams | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.system_stats.cpu.idle           | gauge      | %         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.system_stats.cpu.util           | gauge      | %         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.system_stats.io.incoming.blocks | cumulative | blocks    | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
-      | hardware.system_stats.io.outgoing.blocks | cumulative | blocks    | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.cpu.load.15min                  | gauge      | process   | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.cpu.load.1min                   | gauge      | process   | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.cpu.load.5min                   | gauge      | process   | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.memory.swap.avail               | gauge      | B         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.memory.swap.total               | gauge      | B         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.memory.total                    | gauge      | B         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.memory.used                     | gauge      | B         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.network.ip.incoming.datagrams   | cumulative | datagrams | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.network.ip.outgoing.datagrams   | cumulative | datagrams | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.system_stats.cpu.idle           | gauge      | %         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.system_stats.cpu.util           | gauge      | %         | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.system_stats.io.incoming.blocks | cumulative | blocks    | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
+      | hardware.system_stats.io.outgoing.blocks | cumulative | blocks    | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | None    | None       |
       +------------------------------------------+------------+-----------+--------------------------------------+---------+------------+
 
 Retrieving the actual performance metrics for a node involves a query to return a set of samples:
 
-      [stack@localhost ~]$ ceilometer sample-list --meter hardware.cpu.load.5min -q 'resource_id=d52ebd4f-a28b-49cf-8adc-61847e6bb525'
+      [stack@localhost ~]$ ceilometer sample-list --meter hardware.cpu.load.5min -q 'resource_id=d52ebd4f-a28b-49cf-8adc-61847e6bb525'
       +--------------------------------------+------------------------+-------+--------+---------+---------------------+
-      | Resource ID                          | Name                   | Type  | Volume | Unit    | Timestamp           |
+      | Resource ID                          | Name                   | Type  | Volume | Unit    | Timestamp           |
       +--------------------------------------+------------------------+-------+--------+---------+---------------------+
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.32   | process | 2015-03-13T11:02:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.09   | process | 2015-03-13T10:52:28 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.2    | process | 2015-03-13T10:42:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.07   | process | 2015-03-13T10:32:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.26   | process | 2015-03-13T10:22:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.02   | process | 2015-03-13T10:12:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.14   | process | 2015-03-13T10:02:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.26   | process | 2015-03-13T09:52:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.09   | process | 2015-03-13T09:42:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.65   | process | 2015-03-13T09:32:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.17   | process | 2015-03-13T09:22:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.39   | process | 2015-03-13T09:12:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.13   | process | 2015-03-13T09:02:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.28   | process | 2015-03-13T08:52:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.05   | process | 2015-03-13T08:42:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.2    | process | 2015-03-13T08:32:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.03   | process | 2015-03-13T08:22:27 |
-      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.14   | process | 2015-03-13T08:12:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.32   | process | 2015-03-13T11:02:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.09   | process | 2015-03-13T10:52:28 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.2    | process | 2015-03-13T10:42:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.07   | process | 2015-03-13T10:32:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.26   | process | 2015-03-13T10:22:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.02   | process | 2015-03-13T10:12:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.14   | process | 2015-03-13T10:02:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.26   | process | 2015-03-13T09:52:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.09   | process | 2015-03-13T09:42:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.65   | process | 2015-03-13T09:32:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.17   | process | 2015-03-13T09:22:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.39   | process | 2015-03-13T09:12:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.13   | process | 2015-03-13T09:02:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.28   | process | 2015-03-13T08:52:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.05   | process | 2015-03-13T08:42:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.2    | process | 2015-03-13T08:32:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.03   | process | 2015-03-13T08:22:27 |
+      | d52ebd4f-a28b-49cf-8adc-61847e6bb525 | hardware.cpu.load.5min | gauge | 4.14   | process | 2015-03-13T08:12:27 |
 
 Further information on using the Ceilometer to is available here: <https://www.rdoproject.org/CeilometerQuickStart>
 
@@ -255,17 +255,17 @@ As in the case of the original deployment of the overcloud via Heat, that status
 
 It's also possible to see a history of the events associated with a stack with this command:
 
-      [stack@localhost ~]$ heat event-list overcloud
+      [stack@localhost ~]$ heat event-list overcloud
       +-----------------------------------+--------------------------------------+------------------------+--------------------+----------------------+
-      | resource_name                     | id                                   | resource_status_reason | resource_status    | event_time           |
+      | resource_name                     | id                                   | resource_status_reason | resource_status    | event_time           |
       +-----------------------------------+--------------------------------------+------------------------+--------------------+----------------------+
-      | CephStorageNodesPostDeployment    | 72670265-5145-4bae-b445-f920ccc9aa64 | state changed          | CREATE_COMPLETE    | 2015-03-12T20:19:40Z |
-      | CephStorageNodesPostDeployment    | b41db82a-6e17-4eb6-8666-0d5f60a234f9 | state changed          | CREATE_IN_PROGRESS | 2015-03-12T20:19:37Z |
-      | ControllerNodesPostDeployment     | f91ede39-f2b8-44b2-8644-072a04d619f0 | state changed          | CREATE_COMPLETE    | 2015-03-12T20:19:37Z |
-      | ComputeNodesPostDeployment        | 80912537-d95c-44a6-9975-9ce43d739f8b | state changed          | CREATE_COMPLETE    | 2015-03-12T20:17:58Z |
-      | ControllerNodesPostDeployment     | eadbef1a-e932-4f60-a94d-417007ae6578 | state changed          | CREATE_IN_PROGRESS | 2015-03-12T20:17:38Z |
-      | ControllerCephDeployment          | 47482901-69a7-4699-973d-c507e762dce8 | state changed          | CREATE_COMPLETE    | 2015-03-12T20:17:38Z |
-      | ControllerAllNodesDeployment      | 44436938-71e5-452e-a37f-956f3c8cec8e | state changed          | CREATE_COMPLETE    | 2015-03-12T20:17:38Z |
-      | ComputeNodesPostDeployment        | 4ac03e96-b9e3-437a-b0bb-a21774069abc | state changed          | CREATE_IN_PROGRESS | 2015-03-12T20:17:13Z |
-      | ComputeAllNodesDeployment         | 253244ba-aae4-4cb0-8d85-968699425217 | state changed          | CREATE_COMPLETE    | 2015-03-12T20:17:13Z |
-      | BlockStorageNodesPostDeployment   | cbc1a747-f683-4b74-bbc0-72a8095c8af1 | state changed          | CREATE_COMPLETE    | 2015-03-12T20:17:09Z |
+      | CephStorageNodesPostDeployment    | 72670265-5145-4bae-b445-f920ccc9aa64 | state changed          | CREATE_COMPLETE    | 2015-03-12T20:19:40Z |
+      | CephStorageNodesPostDeployment    | b41db82a-6e17-4eb6-8666-0d5f60a234f9 | state changed          | CREATE_IN_PROGRESS | 2015-03-12T20:19:37Z |
+      | ControllerNodesPostDeployment     | f91ede39-f2b8-44b2-8644-072a04d619f0 | state changed          | CREATE_COMPLETE    | 2015-03-12T20:19:37Z |
+      | ComputeNodesPostDeployment        | 80912537-d95c-44a6-9975-9ce43d739f8b | state changed          | CREATE_COMPLETE    | 2015-03-12T20:17:58Z |
+      | ControllerNodesPostDeployment     | eadbef1a-e932-4f60-a94d-417007ae6578 | state changed          | CREATE_IN_PROGRESS | 2015-03-12T20:17:38Z |
+      | ControllerCephDeployment          | 47482901-69a7-4699-973d-c507e762dce8 | state changed          | CREATE_COMPLETE    | 2015-03-12T20:17:38Z |
+      | ControllerAllNodesDeployment      | 44436938-71e5-452e-a37f-956f3c8cec8e | state changed          | CREATE_COMPLETE    | 2015-03-12T20:17:38Z |
+      | ComputeNodesPostDeployment        | 4ac03e96-b9e3-437a-b0bb-a21774069abc | state changed          | CREATE_IN_PROGRESS | 2015-03-12T20:17:13Z |
+      | ComputeAllNodesDeployment         | 253244ba-aae4-4cb0-8d85-968699425217 | state changed          | CREATE_COMPLETE    | 2015-03-12T20:17:13Z |
+      | BlockStorageNodesPostDeployment   | cbc1a747-f683-4b74-bbc0-72a8095c8af1 | state changed          | CREATE_COMPLETE    | 2015-03-12T20:17:09Z |

--- a/source/troubleshooting/networking.html.md
+++ b/source/troubleshooting/networking.html.md
@@ -36,19 +36,19 @@ A number of tools come in handy when troubleshooting Neutron/Quantum networking 
 
 tcpdump will be your best friend so it's best to learn and understand how to use it. When debugging routing issues with quantum, tcpdump can be used to investigate the ingress and egress of traffic. For example:
 
-           tcpdump -n -i br-int  
+           tcpdump -n -i br-int  
 
 The above command will capature all traffic on the internal bridge interface.
 
-           tcpdump -n -i br-int  -w tcpdump.pcap
+           tcpdump -n -i br-int  -w tcpdump.pcap
 
 The above command will capture all traffic on the internal bridge interface and dump it to a file named tcpdump.pcap.
 
-           tcpdump -r tcpdump.pcap
+           tcpdump -r tcpdump.pcap
 
 The above command will read in a previously created tcpdump file
 
-           tcpdump -n -i any
+           tcpdump -n -i any
 
 The above command will capture all traffic on any interface. ...
 

--- a/source/troubleshooting/qpid-errors.html.md
+++ b/source/troubleshooting/qpid-errors.html.md
@@ -20,16 +20,16 @@ Replace 'cluster-mechanism' with 'ha-mechanism' in /etc/qpidd.conf then restart 
 
 As discussed in [forum thread](http://rdoproject.org/forum/discussion/293/error-on-openstack-status#Item_5|this), the qpid user database may become corrupted. This may be evidenced by error messages such as:
 
-         qpidd: unable to open Berkeley db /var/lib/qpidd/qpidd.sasldb: No such file or directory
+         qpidd: unable to open Berkeley db /var/lib/qpidd/qpidd.sasldb: No such file or directory
 
 You can recreate the sasldb file using the following command:
 
-         saslpasswd2 -f /var/lib/qpidd/qpidd.sasldb -u QPID guest
+         saslpasswd2 -f /var/lib/qpidd/qpidd.sasldb -u QPID guest
 
 Provide the password at the command line (usually 'guest'), and the file will be created. You should further ensure that /etc/cinder/cinder.conf references the correct username and password corresponding with this file. Then restart qpidd:
 
-         service qpidd restart
+         service qpidd restart
 
 You can verify the presence of users accounts in that file with:
 
-         sasldblistusers2 -f /var/lib/qpidd/qpidd.sasldb
+         sasldblistusers2 -f /var/lib/qpidd/qpidd.sasldb


### PR DESCRIPTION
These were likely auto-inserted by the old wiki and preserved in the
conversion to markdown. They can cause problems when copied and pasted
straight into actual config files.