### PR TITLE
add a target highlight and anchor offset

### DIFF
--- a/source/stylesheets/application.css.sass
+++ b/source/stylesheets/application.css.sass
@@ -17,6 +17,7 @@
 @import fonts/fonts.css
 @import vendor/solarized-light.sass
 
+@import lib/target-enhancements.sass
 @import lib/scrollbar-on.sass
 //@import lib/juvia-comments.sass
 

--- a/source/stylesheets/lib/target-enhancements.sass
+++ b/source/stylesheets/lib/target-enhancements.sass
@@ -1,0 +1,41 @@
+@media screen
+  $highlight-color: mix(yellow, white, 50)
+  $target-offset: 3em
+
+  @keyframes highlight
+    0%
+      background-color: white
+    5%
+      background-color: $highlight-color
+    10%
+      background-color: $highlight-color
+    20%
+      background-color: mix($highlight-color, white, 25)
+    25%
+      background-color: $highlight-color
+    70%
+      background-color: $highlight-color
+    100%
+      background-color: white
+
+  *:target
+    position: relative
+
+    &:before,
+    &:after
+      content: ''
+      display: block
+      pointer-events: none
+
+    &:before
+      height: $target-offset
+      margin: -$target-offset 0 0
+
+    &:after
+      animation: highlight 6s ease
+      position: absolute
+      top: calc(#{$target-offset} - 0.25em)
+      right: -0.5em
+      bottom: -0.25em
+      left: -0.5em
+      z-index: -1

--- a/source/stylesheets/lib/target-enhancements.sass
+++ b/source/stylesheets/lib/target-enhancements.sass
@@ -20,6 +20,7 @@
 
   *:target
     position: relative
+    z-index: 100
 
     &:before,
     &:after


### PR DESCRIPTION
when a target in a page is deep linked (selected by a hash in the URL — all headings get autogenerated IDs which are selected hashes), this snippet of CSS adds an offset and a little attention-grabbing animated color (yellow) that fades out