### PR TITLE
Add Packstack requirement for testing

### DIFF
--- a/source/testday/newton/milestone3.html.md
+++ b/source/testday/newton/milestone3.html.md
@@ -34,6 +34,7 @@ You'll want a fresh install with latest updates installed.
 
     yum -y install https://rdoproject.org/repos/openstack-newton/rdo-release-newton.rpm
     
+* For Packstack make sure you set CONFIG_ENABLE_RDO_TESTING=y in your answer file, or that you use the --enable-rdo-testing=y command-line argument.
 * Check for any [workarounds](/testday/newton/workarounds3) required for your platform before the main installation
 * For Packstack based deployment start at step 2 of the [packstack Quickstart](/install/quickstart#Step_2:_Install_Packstack_Installer)
 * For a TripleO-based installs, try the [TripleO quickstart](https://www.rdoproject.org/tripleo/).


### PR DESCRIPTION
Packstack needs CONFIG_ENABLE_RDO_TESTING=y for test days, this was documented under workarounds, since it's required for this task should be in the main document.