### PR TITLE
Document installation requires permissions.

### DIFF
--- a/source/install/quickstart.html.md
+++ b/source/install/quickstart.html.md
@@ -108,7 +108,7 @@ $ sudo yum install -y openstack-packstack
 Packstack takes the work out of manually setting up OpenStack. For a single node OpenStack deployment, run the following command:
 
 ```
-$ packstack --allinone
+$ sudo packstack --allinone
 ```
   
 If you encounter failures, see the [Workarounds](Workarounds) page for tips.


### PR DESCRIPTION
packstack --allinone normally will fail unless some permissions are set.
As it's a quick start guide, do it as root.