### PR TITLE
Run packstack with sudo on quickstart doc

### DIFF
--- a/source/install/quickstart.html.md
+++ b/source/install/quickstart.html.md
@@ -34,7 +34,7 @@ If your system meets all the prerequisites mentioned below, proceed with running
   $ sudo yum install -y https://www.rdoproject.org/repos/rdo-release.rpm
   $ sudo yum update -y
   $ sudo yum install -y openstack-packstack
-  $ packstack --allinone
+  $ sudo packstack --allinone
   ```
 
 * On CentOS:
@@ -43,7 +43,7 @@ If your system meets all the prerequisites mentioned below, proceed with running
   $ sudo yum install -y centos-release-openstack-newton
   $ sudo yum update -y
   $ sudo yum install -y openstack-packstack
-  $ packstack --allinone
+  $ sudo packstack --allinone
   ```
 
 ## Step 0: Prerequisites


### PR DESCRIPTION
If packstack is ran without sudo it will fail. In my case:

--
ERROR : Failed to run remote script, stdout:
stderr: Warning: Permanently added '10.0.2.15' (ECDSA) to the list of
known hosts.
Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
--

I also presume Puppet manifests will fail too if they are not granted
enough privileges.