### PR TITLE
Update trunk.rdoproject.org repository links for ocata m3 testday

### DIFF
--- a/source/testday/ocata/milestone3.html.md
+++ b/source/testday/ocata/milestone3.html.md
@@ -36,8 +36,8 @@ You'll want a fresh install with latest updates installed.
 
     $ yum -y install yum-plugin-priorities
     $ cd /etc/yum.repos.d/
-    $ sudo curl -O http://trunk.rdoproject.org/centos7/delorean-deps.repo
-    $ sudo curl -O http://trunk.rdoproject.org/centos7/current-passed-ci/delorean.repo
+    $ sudo curl -O https://trunk.rdoproject.org/centos7-ocata/delorean-deps.repo
+    $ sudo curl -L -O https://trunk.rdoproject.org/centos7-ocata/current-passed-ci/delorean.repo
     $ sudo yum update -y
 
 * These steps apply to both RHEL 7 and CentOS 7.


### PR DESCRIPTION
Use https instead of http and use centos7-ocata instead of centos7.
centos7 points to master which has been branched to Pike already.
The delorean.repo has an added "-L" because that ends up being
redirected to a CDN.