### PR TITLE
Use centos7-master for m3 test day, not centos7-ocata

### DIFF
--- a/source/testday/ocata/milestone3.html.md
+++ b/source/testday/ocata/milestone3.html.md
@@ -36,8 +36,8 @@ You'll want a fresh install with latest updates installed.
 
     $ yum -y install yum-plugin-priorities
     $ cd /etc/yum.repos.d/
-    $ sudo curl -O https://trunk.rdoproject.org/centos7-ocata/delorean-deps.repo
-    $ sudo curl -L -O https://trunk.rdoproject.org/centos7-ocata/current-passed-ci/delorean.repo
+    $ sudo curl -O https://trunk.rdoproject.org/centos7-master/delorean-deps.repo
+    $ sudo curl -L -O https://trunk.rdoproject.org/centos7-master/current-passed-ci/delorean.repo
     $ sudo yum update -y
 
 * These steps apply to both RHEL 7 and CentOS 7.


### PR DESCRIPTION
It turns out we're going to be using centos7-master for the test
day after all as upstream projects have not quite started branching
just yet.