### PR TITLE
Add clarification on MidoNet 5.4 + RHOSP 10 docs

### DIFF
--- a/source/networking/midonet-integration_midonet-54-rhel7-rhosp10.html.md
+++ b/source/networking/midonet-integration_midonet-54-rhel7-rhosp10.html.md
@@ -49,7 +49,8 @@ export DIB_MIDONET_openstack_version=newton
 As you can see above, we will be installing MidoNet 5.4 from its stable branch,
 for the Newton release. Then clone these two repositories from the MidoNet
 GitHub organization (while the patches are being reviewed upstream) and place
-them inside `/home/stack/custom-images/`.
+them inside `/home/stack/custom-images/`. Then checkout the
+`stable/newton_midonet` branch, as it's the branch that contains all changes.
 
 * [tripleo-puppet-elements][midonet-tpe]
 * [tripleo-heat-templates][midonet-tht]


### PR DESCRIPTION
Users should check out the stable/newton_midonet branch from the cloned
repositories, otherwise they will not find the mentioned files.