### PR TITLE
Add link to tripleo-ci status dashboard

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -99,7 +99,8 @@ hide_metadata: true
           %p.lead
             Check out the
             =link_to("current status", "http://dashboards.rdoproject.org")
-            of the project.
+            of the project and upstream
+            =link_to("tripleo-ci status", "http://status-tripleoci.rhcloud.com/").
                         
       .col-md-4
         .block-heading


### PR DESCRIPTION
Add cross-clink to upstream tripleo-ci status dashboard along with current status of RDO dashboard.