### PR TITLE
Fix link to delorean repos (use https)

### DIFF
--- a/source/testday/pike/milestone3.html.md
+++ b/source/testday/pike/milestone3.html.md
@@ -36,8 +36,8 @@ You'll want a fresh install with latest updates installed.
 
     $ yum -y install yum-plugin-priorities
     $ cd /etc/yum.repos.d/
-    $ sudo curl -O http://trunk.rdoproject.org/centos7/delorean-deps.repo
-    $ sudo curl -O http://trunk.rdoproject.org/centos7/current-passed-ci/delorean.repo
+    $ sudo curl -O https://trunk.rdoproject.org/centos7/delorean-deps.repo
+    $ sudo curl -O https://trunk.rdoproject.org/centos7/current-passed-ci/delorean.repo
     $ sudo yum update -y
 
 * These steps apply to both RHEL 7 and CentOS 7.


### PR DESCRIPTION
The http link is a redirect which is not followed by curl as it is now.
Another option is add the proper parameters to curl; as a change is
needed anyway, better use the correct URL.