### PR TITLE
Remove quickstart references

### DIFF
--- a/source/install/index.html.md
+++ b/source/install/index.html.md
@@ -8,14 +8,14 @@ authors: cbrown ocf, dansmith, dneary, edmv, radez, rbowen, rlandy, slagle, snec
 
 [← Docs](/documentation/)
 
-For an initial test deployment, follow the [Packstack quickstart](/install/packstack). While using Packstack is sufficient as a proof of concept, there are other ways that you can use to deploy OpenStack with RDO. If you need to deploy a production-ready cloud, possibly with HA, see the [TripleO quickstart](/tripleo).
+For an initial test deployment, follow the [Packstack](/install/packstack) instructions. While using Packstack is sufficient as a proof of concept, there are other ways that you can use to deploy OpenStack with RDO. If you need to deploy a production-ready cloud, possibly with HA, see the [TripleO quickstart](/tripleo).
 
 <div class="splits">
 <div class="split-third with-more">
 ### Installation
 
 *   [TripleO quickstart](/tripleo) &ndash; production deployment, with HA
-*   [Packstack quickstart](/install/packstack) &ndash; proof of concept for single node
+*   [Packstack](/install/packstack) &ndash; proof of concept for single node
 *   [More information on Packstack](/documentation/packstack-cookbook/)
 *   [Manual Installation Tutorial](https://docs.openstack.org/ocata/install-guide-rdo/) &ndash; OpenStack upstream documentation
 *   [RDO repositories](/documentation/repositories/)

--- a/source/install/packstack.html.md
+++ b/source/install/packstack.html.md
@@ -1,5 +1,5 @@
 ---
-title: Packstack quickstart
+title: Packstack
 category: documentation
 authors: apevec, dneary, garrett, jasonbrooks, jlibosva, mmagr, pixelbeat, pmyers,
   rbowen, gbraad, cbrown2


### PR DESCRIPTION
This commit removes quickstart references from the Packstack docs
to reduce confusion between Packstack and TripleO QuickStart