### PR TITLE
Update packstack min RAM requirements to match real world

### DIFF
--- a/source/install/packstack.html.md
+++ b/source/install/packstack.html.md
@@ -50,7 +50,7 @@ Name the host with a fully qualified domain name rather than a short-form name t
 
 ### Hardware
 
-Machine with at least 4GB RAM, preferably 6GB RAM, processors with hardware virtualization extensions, and at least one network adapter.
+Machine with at least 16GB RAM, processors with hardware virtualization extensions, and at least one network adapter.
 
 ### Network
 


### PR DESCRIPTION
The docs suggest packstack can be run in a machine with 4 GB
of RAM. While this may have worked in the past, it does not
work any longer. Even installing in a machine with 8 GB triggers
out of memory failures. A 12 GB machine was able to complete the
all-in-one install successfully, but the services almost
immediately start getting reaped by the OOM-killer. Thus document
that 16 GB of RAM is required for packstack.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>