### PR TITLE
Workaround travis breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ rvm:
 sudo: false
 cache: bundler
 script: bundle exec middleman build --verbose
+dist: precise


### PR DESCRIPTION
It seems the upgrade to Trusty broke travis, so we should
for now stay on precise until we know what would be the right fix,
and what is supposed to be supported

Thanks Misc for this (borrowed from oVirt website repo).