### PR TITLE
Remove CentOS 7.3 -> 7.4 instructions for Queens M1 testday

### DIFF
--- a/source/testday/queens/milestone1.html.md
+++ b/source/testday/queens/milestone1.html.md
@@ -31,21 +31,6 @@ We plan to have packages for the following platforms:
 You'll want a fresh install with latest updates installed.
 (Fresh so that there's no hard-to-reproduce interactions with other things.)
 
-### Using CentOS 7.3 pre-release
-
-For this test day, there is a pre-release available of CentOS 7.3. Users
-willing to test RDO using the pre-release must follow these steps:
-
-1. Enable CentOS continuous release (CR) repository and update your system:
-
-       $ sudo yum-config-manager --enable cr
-       $ sudo yum update -y
-
-1. Add the requirements repos for 7.3 pre-release:
-
-       $ cd /etc/yum.repos.d/
-       $ sudo curl -O http://trunk.rdoproject.org/rdo-reqs-pre-7.3/rdo-reqs-pre-7.3.repo
-
 ## How to test?
 
     $ yum -y install yum-plugin-priorities


### PR DESCRIPTION
7.4 is out now, we no longer need those.