### PR TITLE
Add proposal for infra maintenance windows, add link to infra pages

### DIFF
--- a/source/contribute/index.html.md
+++ b/source/contribute/index.html.md
@@ -125,7 +125,7 @@ Join the ask.openstack community to ask and answer questions. The site [ask.open
 
 ### Contribute to the RDO Infrastructure
 
-You can contribute to the RDO Infrastructure maintenance. [This page](/infra/) describes the general infrastructure used by RDO.
+You can contribute to the RDO Infrastructure maintenance. [This page](/infra/) describes the general infrastructure used by RDO. The [infrastructure core administrators](/infra/review-rdo-infra-core) are available to help you if you need anything, and we are also available in the **#rdo** IRC channel in Freenode.
 
 ## Content writing
 

--- a/source/contribute/index.html.md
+++ b/source/contribute/index.html.md
@@ -123,6 +123,10 @@ Join the ask.openstack community to ask and answer questions. The site [ask.open
 
 <a name="write-content"/>
 
+### Contribute to the RDO Infrastructure
+
+You can contribute to the RDO Infrastructure maintenance. [This page](/infra/) describes the general infrastructure used by RDO.
+
 ## Content writing
 
 Help improve the documentation and website! The main pages for contributed content are [documentation](/documentation/), [troubleshooting](/troubleshooting/) and [user stories](/user-stories/).

--- a/source/infra/index.html.md
+++ b/source/infra/index.html.md
@@ -72,6 +72,13 @@ The code lives on several organizations at GitHub:
 * [Infrastructure definition and CI](https://github.com/rdo-infra)
 * [Website, rdoinfo and others](https://github.com/redhat-openstack) 
 
+## Processes and maintenance windows
+
+Refer to the [service continuity page](/infra/service-continuity) for details on our service continuity plans.
+
+The [infrastructure maintenance window](/infra/maintenance-windows) page provides information on our planned
+maintenance windows.
+
 ## CentOS
 
 A number of parts of our infrastructure run at CentOS, including

--- a/source/infra/maintenance-windows.html.md
+++ b/source/infra/maintenance-windows.html.md
@@ -1,0 +1,27 @@
+---
+title: RDO Infra maintenance windows
+category: documentation,infrastructure
+---
+
+# Introduction
+
+Infrastructure systems require regular maintenance to ensure a proper, bug-free operation, and the RDO Infrastructure is no exception.
+This document defines the processes we will follow to run maintenance on the RDO systems.
+
+## Unplanned maintenance
+
+Unplanned outages may come at any time, due to software/hardware errors or any other circumstance that requires a quick change on a
+system to restore its operational state. We will communicate unplanned maintenances as soon as possible, keeping in mind that the
+first priority is to restore service.
+
+## Planned maintenance
+
+Planned maintenance includes any change that requires service downtime, but can be scheduled. We define two maintenance windows for
+our systems:
+
+- The first Tuesday of each month.
+- The third Tuesday of each month.
+
+Having a maintenance window does not necessarily mean all systems will be stopped. If a system requires downtime during one of these
+windows, we will notify it at least 24 hours in advance. Communications will be sent to **dev@lists.rdoproject.org**,
+**users@lists.rdoproject.org**, and other lists if appropriate.


### PR DESCRIPTION
This commit adds a proposal for the RDO infrastructure maintenance
windows, and a link to the infra pages in the /contribute page.
Before this, the whole /infra tree was not linked from anywhere in
the web page.