### PR TITLE
Stop advertising the #rdo-puppet channel

### DIFF
--- a/source/contribute/index.html.md
+++ b/source/contribute/index.html.md
@@ -90,7 +90,6 @@ consult our [mentors list](/contribute/mentors).
 Come chat in real-time with RDO users on **IRC** on the [Freenode](http://freenode.net) server:
 
 * **#rdo**: Discussion around RDO in general ([transcripts](http://eavesdrop.openstack.org/irclogs/%23rdo/))
-* **#rdo-puppet**: Discussion around deploying RDO with Packstack and it's puppet modules
 * **#openstack**: Discussion around OpenStack with the broader OpenStack community
 * **#centos-devel**: Discussion around the CentOS [Cloud Special Interest Group (SIG)](https://wiki.centos.org/SpecialInterestGroup/Cloud)
 

--- a/source/newsletter/TEMPLATE.txt
+++ b/source/newsletter/TEMPLATE.txt
@@ -64,7 +64,6 @@ RDO community. The best ways are ...
 
 ### IRC 
 * IRC - #rdo on Freenode.irc.net
-* Puppet module development - #rdo-puppet
 
 ### Social Media
 * [Follow us on Twitter](http://twitter.com/rdocommunity )


### PR DESCRIPTION
The #rdo-puppet channel doesn't represent enough volume or scope to
compete against #rdo, let's funnel everyone directly to #rdo.