### PR TITLE
Sort the blog post on the author page

### DIFF
--- a/source/author.html.haml
+++ b/source/author.html.haml
@@ -13,7 +13,7 @@
 
   - if pages
 
-    - pages.each do |page|
+    - pages.select{ |p| defined? p.date }.sort_by{ |p| p.date}.reverse.each do |page|
       - if (defined? page.title) && (defined? page.published && page.published?)
 
         -#%li= page.public_methods


### PR DESCRIPTION
Due to others pages having a author field but no date, we have
to filter by date, and reverse the result, since we want newer content
on top. Requested by rbowen.