### PR TITLE
Add a automated checkout of the submodule on build

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -203,7 +203,7 @@ configure :development do
   next if ARGV.include? 'deploy'
 
   puts "\nUpdating git submodules..."
-  puts `git submodule init && git submodule sync`
+  puts `git submodule init && git submodule sync && git submodule update`
   puts `git submodule foreach "git pull -qf origin master"`
   `git commit -q -m "updated events" data/events &>/dev/null`
   puts "\n"


### PR DESCRIPTION
If a contributer run directly run-server.sh, the data/events
directory while be unitialized, and this will produce a rather
intimidating backtrace. Since that's not very user friendly and since
the error message give 0 clue on how to fix this, we should
make sure the repository is up to date before starting the server