### PR TITLE
workaround: instance provision fails

### DIFF
--- a/source/testday/workarounds.html.md
+++ b/source/testday/workarounds.html.md
@@ -24,3 +24,39 @@ Describe symptoms here
 ##### workaround
 
 Describe workaround here
+
+###  Nova instance provision fails when host is not mapped to any cell
+
+*   **Bug:** <https://bugzilla.redhat.com/show_bug.cgi?id=1480326>
+*   **Affects:** RHEL 7
+*   **Installation:** packstack
+
+##### symptoms
+
+The instance fails to start with the following error:
+
+> Setup is incomplete.: HostMappingNotFound: Host '<hostname>' is not mapped to any cell
+
+The host is not mapped to any cell:
+
+```
+[root@host ~(keystone_admin)]# nova-manage cell_v2 list_hosts
++-----------+-----------+----------+
+| Cell Name | Cell UUID | Hostname |
++-----------+-----------+----------+
++-----------+-----------+----------+
+```
+
+##### workaround
+
+Manually run cell_v2 discover_hosts
+
+```
+[root@host ~(keystone_admin)]# nova-manage cell_v2 discover_hosts --verbose
+[root@host ~(keystone_admin)]# nova-manage cell_v2 list_hosts
++-----------+--------------------------------------+----------------+
+| Cell Name |              Cell UUID               |    Hostname    |
++-----------+--------------------------------------+----------------+
+|  default  | 88a398e2-846d-45ea-982b-58ae14dcf4df | host.lab.local |
++-----------+--------------------------------------+----------------+
+```


### PR DESCRIPTION
After running packstack --allinone, I cannot start any instance because the host
is not mapped to any cell. The workaround provided in BZ#1480326 did the trick.