### PR TITLE
Update packstack.html.md

### DIFF
--- a/source/install/packstack.html.md
+++ b/source/install/packstack.html.md
@@ -33,6 +33,7 @@ If your system meets all the prerequisites mentioned below, proceed with running
 
   ```
   $ sudo yum install -y centos-release-openstack-queens
+  $ sudo yum install -y python-pip
   $ sudo yum update -y
   $ sudo yum install -y openstack-packstack
   $ sudo packstack --allinone


### PR DESCRIPTION
there is a bug where the "all in one" will not start if a minimal install of the os is done, if pip in NOT installed.

 sudo packstack --allinone --dry-run
ERROR:root:Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/packstack/installer/run_setup.py", line 991, in main
    optParser = initCmdLineParser()
  File "/usr/lib/python2.7/site-packages/packstack/installer/run_setup.py", line 840, in initCmdLineParser
    parser = OptionParser(usage=usage, version="%prog {0}".format(version_info.version_string()))
  File "/usr/lib/python2.7/site-packages/pbr/version.py", line 466, in version_string
    return self.semantic_version().brief_string()
  File "/usr/lib/python2.7/site-packages/pbr/version.py", line 461, in semantic_version
    self._semantic = self._get_version_from_pkg_resources()
  File "/usr/lib/python2.7/site-packages/pbr/version.py", line 438, in _get_version_from_pkg_resources
    import pkg_resources
ImportError: No module named pkg_resources