### PR TITLE
Update packstack.html.md

### DIFF
--- a/source/install/packstack.html.md
+++ b/source/install/packstack.html.md
@@ -11,6 +11,10 @@ This document shows how to spin up a proof of concept cloud on one node, using t
 
 The instructions apply to the current **Queens** release.
 
+###WARNING####
+READ this document in full, THEN choose your install path:
+Don't just start typing commands at "## Summary for the impatient" and proceed downwards through the page.
+
 ## Summary for the impatient
 
 If you are using non-English locale make sure your `/etc/environment` is populated:


### PR DESCRIPTION
needs to make it clear for  "happy typists" types,
 because invariably they hit " sudo packstack --allinone"
and it's not actually what they wanted to do at that stage.