### PR TITLE
Add "yum update" as a first step for CentOS

### DIFF
--- a/source/install/packstack.html.md
+++ b/source/install/packstack.html.md
@@ -32,6 +32,7 @@ If your system meets all the prerequisites mentioned below, proceed with running
 * On CentOS:
 
   ```
+  $ sudo yum update -y
   $ sudo yum install -y centos-release-openstack-queens
   $ sudo yum update -y
   $ sudo yum install -y openstack-packstack


### PR DESCRIPTION
There is a bug in centos-release that affects fresh CentOS 7.5.1804 installations. The issue is that the contentdir yum variable is incorrectly set to altarch instead of centos, and this affects people who install an additional repository (such as centos-release-openstack-queens) as their first step, prior to updating. If they install centos-release-openstack-queens first and run "yum update", they will get 404 errors for the openstack repository due to the wrong path pointing to altarch instead of centos. Running "yum update" first will fix the contentdir variable that is needed for centos-release-openstack-queens. This variable is not used by core CentOS repositories. This bug has been fixed in the centos-release package that is in updates, and will eventually be included in CentOS 7.6.xxxx. The extra "yum update" step can be removed when CentOS 7.6.xxxx is released, but that is still quite a few months ahead.