### PR TITLE
Update a couple of URLs in dlrn.html.md

### DIFF
--- a/source/what/dlrn.html.md
+++ b/source/what/dlrn.html.md
@@ -3,7 +3,7 @@ title: DLRN - What is it, what we use it for
 ---
 
 # DLRN: What it is, what we use it for
-[DLRN](https://github.com/openstack-packages/DLRN) (can be read as "Delorean") is an application that helps us do _continuous packaging_ of RDO. It is used to build packages using the latest commit from each of the OpenStack project repositories.
+[DLRN](https://github.com/softwarefactory-project/DLRN) (can be read as "Delorean") is an application that helps us do _continuous packaging_ of RDO. It is used to build packages using the latest commit from each of the OpenStack project repositories.
 
 DLRN can be run as a standalone application to create a single package, or periodically (using a cron job) to rebuild all packages listed for a specific release.
 
@@ -12,7 +12,7 @@ The basic DLRN flow is:
 
 - For each package listed in the [RDO metadata file](https://github.com/redhat-openstack/rdoinfo/blob/master/rdo.yml):
     - Fetch the latest upstream commit from the OpenStack Git repositories
-    - Fetch the latest commit from the [distgit](https://www.rdoproject.org/documentation/rdo-packaging/#distgit---where-the-spec-file-lives) repositories
+    - Fetch the latest commit from the [distgit](https://www.rdoproject.org/documentation/intro-packaging/#distgit---where-the-spec-file-lives) repositories
     - Build an RPM package using the source and distgit commits
     - Create a YUM repository with that package, and the latest build package for the other packages
     - If a package build fails, open a review in [the RDO Gerrit](https://review.rdoproject.org) to track and fix the issue.
@@ -35,7 +35,7 @@ DLRN can build packages using different upstream branches, not only master. For 
 This project (openstack-watcher) is built for Ocata (master) and Newton.
 
 ### Setting up a DLRN instance
-You can follow the instructions from the [README file](https://github.com/openstack-packages/DLRN/blob/master/README.rst) to set up a test instance. The Puppet module we use to build the RDO instances [is also available](https://github.com/rdo-infra/puppet-dlrn) if you want to take a look at how to configure multiple instances on a single machine.
+You can follow the instructions from the [README file](https://github.com/softwarefactory-project/DLRN/blob/master/README.rst) to set up a test instance. The Puppet module we use to build the RDO instances [is also available](https://github.com/rdo-infra/puppet-dlrn) if you want to take a look at how to configure multiple instances on a single machine.
 
 ----
 


### PR DESCRIPTION
 * The "Where the spec file lives" link didn't go to the correct page
 * The GitHub URLs automatically redirect to the correct repo, but may
   as well be updated to reference the new URL