### PR TITLE
fix img width

### DIFF
--- a/source/stylesheets/vendor/main.css
+++ b/source/stylesheets/vendor/main.css
@@ -58,6 +58,8 @@ hr {
 
 img {
     vertical-align: middle;
+    max-width: 100%
+    height: auto;
 }
 
 /*


### PR DESCRIPTION
The markdown templates produce "img" elements with fixed width and height according to the image original size. On mobile devices, this makes the images hard to view - if they are too big, they can run off the page, and may be a little too big. Using "max-width: 100%" makes the images smaller so they fit on the page, and using "height: auto" makes the height adjust to the width. This is important in the "ducks" page: http://rdoproject.org/rdo/ducks/