### PR TITLE
Remove yum-plugin-priorities install task

### DIFF
--- a/source/testday/victoria/milestone1.html.md
+++ b/source/testday/victoria/milestone1.html.md
@@ -30,11 +30,10 @@ You'll want a fresh install with latest updates installed.
 
 ## How to test?
 
-    $ yum -y install yum-plugin-priorities
     $ cd /etc/yum.repos.d/
     $ sudo curl -L -O http://trunk.rdoproject.org/centos8/delorean-deps.repo
     $ sudo curl -L -O http://trunk.rdoproject.org/centos8/current-passed-ci/delorean.repo
-    $ sudo yum update -y
+    $ sudo dnf update -y
 
 * These steps apply to both RHEL 8 and CentOS 8.
 

--- a/source/testday/victoria/milestone3.html.md
+++ b/source/testday/victoria/milestone3.html.md
@@ -30,11 +30,10 @@ You'll want a fresh install with latest updates installed.
 
 ## How to test?
 
-    $ yum -y install yum-plugin-priorities
     $ cd /etc/yum.repos.d/
     $ sudo curl -L -O http://trunk.rdoproject.org/centos8/delorean-deps.repo
     $ sudo curl -L -O http://trunk.rdoproject.org/centos8/current-passed-ci/delorean.repo
-    $ sudo yum update -y
+    $ sudo dnf update -y
 
 * These steps apply to both RHEL 8 and CentOS 8.
 

--- a/source/testday/victoria/releasecandidate1.html.md
+++ b/source/testday/victoria/releasecandidate1.html.md
@@ -30,11 +30,10 @@ You'll want a fresh install with latest updates installed.
 
 ## How to test?
 
-    $ yum -y install yum-plugin-priorities
     $ cd /etc/yum.repos.d/
     $ sudo curl -L -O http://trunk.rdoproject.org/centos8/delorean-deps.repo
     $ sudo curl -L -O http://trunk.rdoproject.org/centos8/current-passed-ci/delorean.repo
-    $ sudo yum update -y
+    $ sudo dnf update -y
 
 * These steps apply to both RHEL 8 and CentOS 8.
 

--- a/source/testday/wallaby/milestone1.html.md
+++ b/source/testday/wallaby/milestone1.html.md
@@ -28,11 +28,10 @@ You'll want a fresh install with latest updates installed. (Fresh so that there'
 
 ## How to test?
 
-    $ yum -y install yum-plugin-priorities
     $ cd /etc/yum.repos.d/
     $ sudo curl -L -O http://trunk.rdoproject.org/centos8/delorean-deps.repo
     $ sudo curl -L -O http://trunk.rdoproject.org/centos8/current-passed-ci/delorean.repo
-    $ sudo yum update -y
+    $ sudo dnf update -y
 
 * These steps apply to both RHEL 8 and CentOS 8.
 

--- a/source/testday/wallaby/milestone3.html.md
+++ b/source/testday/wallaby/milestone3.html.md
@@ -28,11 +28,10 @@ You'll want a fresh install with latest updates installed. (Fresh so that there'
 
 ## How to test?
 
-    $ yum -y install yum-plugin-priorities
     $ cd /etc/yum.repos.d/
     $ sudo curl -L -O http://trunk.rdoproject.org/centos8/delorean-deps.repo
     $ sudo curl -L -O http://trunk.rdoproject.org/centos8/current-passed-ci/delorean.repo
-    $ sudo yum update -y
+    $ sudo dnf update -y
 
 * These steps apply to both RHEL 8 and CentOS 8.
 


### PR DESCRIPTION
yum-plugin-priorities is not available for EL8 distros
and is not needed for handling repo priorities. Also
use dnf instead of yum as victoria+ releases are EL8 only.