### PR TITLE
Update the list of supported releases

### DIFF
--- a/source/rdo/release-cadence.html.md
+++ b/source/rdo/release-cadence.html.md
@@ -20,12 +20,11 @@ The OpenStack package maintainer team keeps only the latest OpenStack developmen
 Due to the slower release cadence of RHEL and therefore CentOS, only the most recent release plus the previous one are supported, in keeping up with upstream policy. Older versions of the operating system such as CentOS 6 do not receive later releases.
 
 |----------------------|----------|-----------|
+| RHEL 8 and CentOS 8  | Victoria | supported |
 | RHEL 8 and CentOS 8  | Ussuri   | supported |
 | RHEL 8 and CentOS 8  | Train    | supported |
 | RHEL 7 and CentOS 7  | Train    | supported |
 | RHEL 7 and CentOS 7  | Stein    | supported |
-| RHEL 7 and CentOS 7  | Rocky    | supported |
-| RHEL 7 and CentOS 7  | Queens   | supported |
 
 ### References
 


### PR DESCRIPTION
Adding Victoria as supported.
Rmoving rocky which is now in Extended Maintenance upstream (it means no new releases, so not supported from CloudSIG point of view).