### PR TITLE
Update the RDO main page: RDO is now based on CentOS Stream

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -53,7 +53,7 @@ hide_metadata: true
     .intro-text
       :markdown
 
-         OpenStack, packaged for and tested on CentOS.
+         OpenStack, packaged for and tested on CentOS Stream.
          
          <span class="btn">[Get Started →](/use/)</span>
 
@@ -117,7 +117,7 @@ hide_metadata: true
             {:.floatright.openstack-distro}
             ![An Openstack Distribution](/images/wiki/Openstack-distribution.png)
 
-            RDO is a community of people using and deploying OpenStack on CentOS, Fedora, and Red Hat Enterprise Linux. We have [documentation to help get started](/use/), [mailing lists](/contribute/mailing-lists/) where you can connect with other users, and [community-supported packages](/install/packstack/) of the most up-to-date OpenStack releases available for download.
+            RDO is a community of people using and deploying OpenStack on CentOS Stream. We have [documentation to help get started](/use/), [mailing lists](/contribute/mailing-lists/) where you can connect with other users, and [community-supported packages](/install/packstack/) of the most up-to-date OpenStack releases available for download.
 
             If you are looking for enterprise-level support, or information on partner certification, Red Hat also offers [Red Hat OpenStack Platform](//redhat.com/en/technologies/linux-platforms/openstack-platform).
 


### PR DESCRIPTION
The RDO project decided to build primarily on CentOS Stream and no longer on CentOS or RHEL. Fedora isn't supported anymore for a while now.