### PR TITLE
Fix back link from books

### DIFF
--- a/source/documentation/books.html.md
+++ b/source/documentation/books.html.md
@@ -6,8 +6,7 @@ authors: rbowen
 
 # Books
 
-[← Docs](/documentation/)
+[← Use](/use/)
 
-*   [OpenStack Cloud Computing Cookbook](https://amzn.com/1782174788), by Kevin Jackson
-*   [OpenStack Essentials](https://www.packtpub.com/books/info/authors/dan-radez), by Dan Radez
-
+- [OpenStack Cloud Computing Cookbook](https://amzn.com/1782174788), by Kevin Jackson
+- [OpenStack Essentials](https://www.packtpub.com/books/info/authors/dan-radez), by Dan Radez


### PR DESCRIPTION
There never was a real documentation/ main page. Going back to where this page is linked from.